### PR TITLE
Feat: Text Atoms 구현

### DIFF
--- a/client/src/components/UI/atoms/text/Text.stories.tsx
+++ b/client/src/components/UI/atoms/text/Text.stories.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import Text from './Text';
+
+export default {
+  title: 'Atoms/Text',
+  component: Text,
+} as ComponentMeta<typeof Text>;
+
+const Template: ComponentStory<typeof Text> = (args) => <Text {...args} />;
+
+export const FontOptions = Template.bind({});
+FontOptions.args = {
+  size: 'm',
+  weight: 'regular',
+  color: 'black',
+  children: 'Text',
+};

--- a/client/src/components/UI/atoms/text/Text.tsx
+++ b/client/src/components/UI/atoms/text/Text.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import './text.scss';
+
+interface TextProps {
+  size?: 'xs' | 's' | 'm' | 'lg' | 'xlg' | '2xlg';
+  weight?: 'regular' | 'medium' | 'semibold' | 'bold';
+  color?: 'black' | 'green' | 'white' | 'blue' | 'red';
+  children: string;
+}
+
+function Text({
+  size = 'm',
+  weight = 'regular',
+  color = 'black',
+  children,
+}: TextProps) {
+  return (
+    <span
+      className={[
+        'text',
+        `text--${size}`,
+        `text--${weight}`,
+        `text--${color}`,
+      ].join(' ')}
+    >
+      {children}
+    </span>
+  );
+}
+
+export default Text;

--- a/client/src/components/UI/atoms/text/text.scss
+++ b/client/src/components/UI/atoms/text/text.scss
@@ -1,0 +1,67 @@
+@import '../../../../utils/_utils';
+
+.text {
+  font-size: 1rem;
+  font-weight: 400;
+  color: $black;
+}
+
+.text--xs {
+  font-size: 0.75rem;
+}
+
+.text--s {
+  font-size: 0.875rem;
+}
+
+.text--m {
+  font-size: 1rem;
+}
+
+.text--lg {
+  font-size: 1.25rem;
+}
+
+.text--xlg {
+  font-size: 1.5rem;
+}
+
+.text--2xlg {
+  font-size: 1.75rem;
+}
+
+.text--regular {
+  font-weight: 400;
+}
+
+.text--medium {
+  font-weight: 500;
+}
+
+.text--semibold {
+  font-weight: 600;
+}
+
+.text--bold {
+  font-weight: 700;
+}
+
+.text--black {
+  color: $black;
+}
+
+.text--green {
+  color: $deep-green;
+}
+
+.text--white {
+  color: $white;
+}
+
+.text--blue {
+  color: $blue;
+}
+
+.text--red {
+  color: $red;
+}


### PR DESCRIPTION
Text Atoms 구현

props로 size weight color와 children을 받습니다.
children만 필수값이고 나머지는 입력하지 않으면 디폴트값으로 들어갑니다.

size는 'xs' | 's' | 'm' | 'lg' | 'xlg' | '2xlg' 6단계로,
weight은 'regular' | 'medium' | 'semibold' | 'bold' 4단계로,
color는 'black' | 'green' | 'white' | 'blue' | 'red' 5가지 옵션이 준비되어있습니다.