### PR TITLE
Refactor: scss 모듈화에 따른 클래스명 간소화

### DIFF
--- a/client/src/components/UI/atoms/Icon/Icon.tsx
+++ b/client/src/components/UI/atoms/Icon/Icon.tsx
@@ -1,5 +1,6 @@
 import * as icons from './icons';
-import './icon.scss';
+import styles from './icon.module.scss';
+import classNames from 'classnames/bind';
 
 interface IconProps {
   icon: keyof typeof icons;
@@ -13,15 +14,10 @@ const Icon = ({
   color = 'black',
 }: IconProps) => {
   const SVG = icons[icon];
+  const cx = classNames.bind(styles);
 
   return (
-    <span
-      className={[
-        'icon-container',
-        `icon-container--${size}`,
-        `icon-container--${color}`,
-      ].join(' ')}
-    >
+    <span className={cx('icon-container', `${size}`, `${color}`)}>
       <SVG />
     </span>
   );

--- a/client/src/components/UI/atoms/Icon/icon.module.scss
+++ b/client/src/components/UI/atoms/Icon/icon.module.scss
@@ -1,16 +1,17 @@
 @import '/src/utils/utils';
 
 @mixin icon-size($class, $size) {
-    &.icon-container--#{$class} {
+    &.#{$class} {
         svg {
-            width: #{$size}px;
+            display: block;
+            width: #{$size/$font-size}rem;
             height: auto;
         }
     }
 };
 
 @mixin icon-color($class, $color) {
-    &.icon-container--#{$class} {
+    &.#{$class} {
         svg {
             fill: $color;
         }
@@ -19,7 +20,7 @@
 
 .icon-container {
     display: inline-block;
-    
+
     @include icon-size('xl', 50);
     @include icon-size('l', 40);
     @include icon-size('m', 30);

--- a/client/src/utils/_utils.scss
+++ b/client/src/utils/_utils.scss
@@ -11,3 +11,5 @@ $red: #f24e1e;
 $font-medium: 500;
 $font-semibold: 600;
 $font-bold: 700;
+
+$font-size: 16;


### PR DESCRIPTION
- scss 모듈화에 따른 클래스명 간소화
- util 스타일에 `font-size` 변수 추가
- px -> rem 단위 수정