### PR TITLE
Feat: 메인 메뉴 Link 연결 및 active 스타일 적용

### DIFF
--- a/client/.storybook/main.js
+++ b/client/.storybook/main.js
@@ -6,6 +6,7 @@ module.exports = {
     '@storybook/addon-interactions',
     '@storybook/preset-create-react-app',
     '@storybook/preset-scss',
+    "storybook-addon-react-router-v6"
   ],
   framework: '@storybook/react',
   core: {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -55,6 +55,7 @@
         "eslint-plugin-prettier": "^4.2.1",
         "prettier": "2.8.3",
         "prop-types": "^15.8.1",
+        "storybook-addon-react-router-v6": "^0.2.1",
         "typescript": "^4.9.4",
         "webpack": "^5.75.0"
       }
@@ -31755,6 +31756,34 @@
       "integrity": "sha512-siT1RiqlfQnGqgT/YzXVUNsom9S0H1OX+dpdGN1xkyYATo4I6sep5NmsRD/40s3IIOvlCq6akxkqG82urIZW1w==",
       "dev": true
     },
+    "node_modules/storybook-addon-react-router-v6": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/storybook-addon-react-router-v6/-/storybook-addon-react-router-v6-0.2.1.tgz",
+      "integrity": "sha512-dwYLaE6/bsGnkTn1l5rb5SYIhv2xwwSeRkhWX86bihDWJjz/+NlWSN+r4Kp2WNMVN9vEhMleunXPiGJiFUn7Hg==",
+      "dev": true,
+      "dependencies": {
+        "react-inspector": "^5.1.1"
+      },
+      "peerDependencies": {
+        "@storybook/addons": "^6.4.0",
+        "@storybook/api": "^6.4.0",
+        "@storybook/components": "^6.4.0",
+        "@storybook/core-events": "^6.4.0",
+        "@storybook/theming": "^6.4.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-router": "^6.3.0",
+        "react-router-dom": "^6.3.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/stream-browserify": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
@@ -58864,6 +58893,15 @@
       "resolved": "https://registry.npmjs.org/store2/-/store2-2.14.2.tgz",
       "integrity": "sha512-siT1RiqlfQnGqgT/YzXVUNsom9S0H1OX+dpdGN1xkyYATo4I6sep5NmsRD/40s3IIOvlCq6akxkqG82urIZW1w==",
       "dev": true
+    },
+    "storybook-addon-react-router-v6": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/storybook-addon-react-router-v6/-/storybook-addon-react-router-v6-0.2.1.tgz",
+      "integrity": "sha512-dwYLaE6/bsGnkTn1l5rb5SYIhv2xwwSeRkhWX86bihDWJjz/+NlWSN+r4Kp2WNMVN9vEhMleunXPiGJiFUn7Hg==",
+      "dev": true,
+      "requires": {
+        "react-inspector": "^5.1.1"
+      }
     },
     "stream-browserify": {
       "version": "2.0.2",

--- a/client/package.json
+++ b/client/package.json
@@ -87,6 +87,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "prettier": "2.8.3",
     "prop-types": "^15.8.1",
+    "storybook-addon-react-router-v6": "^0.2.1",
     "typescript": "^4.9.4",
     "webpack": "^5.75.0"
   },

--- a/client/src/components/UI/molecules/GNB/Menu/GlobalMenu.stories.tsx
+++ b/client/src/components/UI/molecules/GNB/Menu/GlobalMenu.stories.tsx
@@ -1,9 +1,11 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { withRouter } from 'storybook-addon-react-router-v6';
 import GlobalMenu from './GlobalMenu';
 
 export default {
   title: 'Molecules/GNB',
   component: GlobalMenu,
+  decorators: [withRouter],
 } as ComponentMeta<typeof GlobalMenu>;
 
 const Template: ComponentStory<typeof GlobalMenu> = () => <GlobalMenu />;

--- a/client/src/components/UI/molecules/GNB/Menu/GlobalMenu.tsx
+++ b/client/src/components/UI/molecules/GNB/Menu/GlobalMenu.tsx
@@ -1,6 +1,7 @@
 import styles from './globalmenu.module.scss';
 import classNames from 'classnames/bind';
-import { Button, Icon, Text } from '../../../atoms';
+import { Icon, Text } from '../../../atoms';
+import { Link } from 'react-router-dom';
 
 // Todo: active 클래스명 붙이는 조건 추가
 const GlobalMenu = () => {
@@ -9,24 +10,20 @@ const GlobalMenu = () => {
   return (
     <ul className={cx('menu-lists')}>
       <li className={cx('menu-list', 'active')}>
-        <Button theme="transparent" size="auto">
-          <>
-            <Icon icon="MdOutlineQueueMusic" size="m" color="gray" />
-            <Text size="lg" color="gray">
-              곡
-            </Text>
-          </>
-        </Button>
+        <Link to="/">
+          <Icon icon="MdOutlineQueueMusic" size="m" color="gray" />
+          <Text size="lg" color="gray">
+            곡
+          </Text>
+        </Link>
       </li>
       <li className={cx('menu-list')}>
-        <Button theme="transparent" size="auto">
-          <>
-            <Icon icon="MdPiano" size="s" color="gray" />
-            <Text size="lg" color="gray">
-              악기
-            </Text>
-          </>
-        </Button>
+        <Link to="/instrument">
+          <Icon icon="MdPiano" size="s" color="gray" />
+          <Text size="lg" color="gray">
+            악기
+          </Text>
+        </Link>
       </li>
     </ul>
   );

--- a/client/src/components/UI/molecules/GNB/Menu/GlobalMenu.tsx
+++ b/client/src/components/UI/molecules/GNB/Menu/GlobalMenu.tsx
@@ -1,15 +1,15 @@
 import styles from './globalmenu.module.scss';
 import classNames from 'classnames/bind';
 import { Icon, Text } from '../../../atoms';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 
-// Todo: active 클래스명 붙이는 조건 추가
 const GlobalMenu = () => {
   const cx = classNames.bind(styles);
+  const { pathname } = useLocation();
 
   return (
     <ul className={cx('menu-lists')}>
-      <li className={cx('menu-list', 'active')}>
+      <li className={cx('menu-list', pathname === '/' && 'active')}>
         <Link to="/">
           <Icon icon="MdOutlineQueueMusic" size="m" color="gray" />
           <Text size="lg" color="gray">
@@ -17,7 +17,7 @@ const GlobalMenu = () => {
           </Text>
         </Link>
       </li>
-      <li className={cx('menu-list')}>
+      <li className={cx('menu-list', pathname === '/instrument' && 'active')}>
         <Link to="/instrument">
           <Icon icon="MdPiano" size="s" color="gray" />
           <Text size="lg" color="gray">

--- a/client/src/components/UI/molecules/GNB/Menu/globalmenu.module.scss
+++ b/client/src/components/UI/molecules/GNB/Menu/globalmenu.module.scss
@@ -6,8 +6,13 @@
     .menu-list {
         margin: 0 1.5rem;
 
-        span {
-            padding-left: 5px;
+        a {
+            display: flex;
+            align-items: center;
+        
+            span {
+                padding-left: 5px;
+            }
         }
 
         &.active {

--- a/client/src/components/UI/organisms/Header/Header.stories.tsx
+++ b/client/src/components/UI/organisms/Header/Header.stories.tsx
@@ -1,9 +1,11 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { withRouter } from 'storybook-addon-react-router-v6';
 import Headers from './Header';
 
 export default {
   title: 'Organisms/Header',
   component: Headers,
+  decorators: [withRouter],
 } as ComponentMeta<typeof Headers>;
 
 const Template: ComponentStory<typeof Headers> = () => <Headers />;


### PR DESCRIPTION
📍 메인 메뉴(GlobalMenu molecule) Link
- 기존에는 버튼에 useNavigate를 이용해 페이지 이동을 구현하려고 했지만, 특정 로직이 있는 것이 아니라 단순 페이지 이동이므로 Link를 쓰는 것이 더 적합하다고 생각하여 버튼을 삭제하고 Link로 수정하였습니다.
- Link로 수정하면서 jsx 구조가 바껴서 스타일 수정하였습니다.

📍 Active 스타일 적용
- useLocation의 pathname을 활용하여 pathname이 해당 메뉴의 경로와 일치할 경우 `active` 클래스명을 붙여 active 스타일을 적용할 수 있도록 하였습니다.

📍 준일님이 아래 PR에서 스토리북 라우터 애드온을 추가하신듯하여 패키지는 push하지 않았습니다.