### PR TITLE
Feat: 악기 페이지 구현

### DIFF
--- a/client/.storybook/preview.js
+++ b/client/.storybook/preview.js
@@ -1,6 +1,7 @@
 import '../src/index.scss';
 import { Provider } from "react-redux"
 import { store } from "../src/redux/store"
+import { withRouter } from 'storybook-addon-react-router-v6';
 
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
@@ -18,4 +19,5 @@ export const decorators = [
       <Story />
     </Provider>
   ),
+  withRouter
 ]

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,5 +1,5 @@
 import { Route, Routes } from 'react-router-dom';
-import { Layout } from './components/pages';
+import { Instrument, Layout } from './components/pages';
 import Test from './components/pages/Test';
 import { UserAuth } from './components/UI/organisms';
 import { BrowserRouter } from 'react-router-dom';
@@ -10,11 +10,10 @@ function App() {
       <Routes>
         <Route path="/" element={<Layout />}>
           <Route index element={<Test />} />
+          <Route path="instrument" element={<Instrument />} />
           {/* MainPage 등 */}
         </Route>
         <Route path="/auth" element={<UserAuth type="Login" />}></Route>
-        {/* Login */}
-        {/* SignUp */}
         {/* NotFound */}
       </Routes>
     </BrowserRouter>

--- a/client/src/components/UI/molecules/GNB/Menu/GlobalMenu.stories.tsx
+++ b/client/src/components/UI/molecules/GNB/Menu/GlobalMenu.stories.tsx
@@ -1,11 +1,9 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react';
-import { withRouter } from 'storybook-addon-react-router-v6';
 import GlobalMenu from './GlobalMenu';
 
 export default {
   title: 'Molecules/GNB',
   component: GlobalMenu,
-  decorators: [withRouter],
 } as ComponentMeta<typeof GlobalMenu>;
 
 const Template: ComponentStory<typeof GlobalMenu> = () => <GlobalMenu />;

--- a/client/src/components/UI/molecules/InstrumentCard/InstrumentCard.stories.tsx
+++ b/client/src/components/UI/molecules/InstrumentCard/InstrumentCard.stories.tsx
@@ -1,18 +1,18 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react';
-import InstrumentCards from './InstrumentCard';
+import InstrumentCard from './InstrumentCard';
 
 export default {
   title: 'Molecules/InstrumentCard',
-  component: InstrumentCards,
-} as ComponentMeta<typeof InstrumentCards>;
+  component: InstrumentCard,
+} as ComponentMeta<typeof InstrumentCard>;
 
-const Template: ComponentStory<typeof InstrumentCards> = (args) => (
-  <InstrumentCards {...args} />
+const Template: ComponentStory<typeof InstrumentCard> = (args) => (
+  <InstrumentCard {...args} />
 );
 
-export const InstrumentCard = Template.bind({});
-InstrumentCard.args = {
+export const Default = Template.bind({});
+Default.args = {
   src: 'https://images.unsplash.com/photo-1520523839897-bd0b52f945a0?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=2340&q=80',
-  type: '피아노',
+  type: 'piano',
   sheets: '13',
 };

--- a/client/src/components/UI/molecules/InstrumentCard/InstrumentCard.tsx
+++ b/client/src/components/UI/molecules/InstrumentCard/InstrumentCard.tsx
@@ -17,7 +17,7 @@ const InstrumentCard = ({ src, type, sheets }: InstrumentCardProps) => {
         <ImgLayout shape="square" size="responsive" src={src} alt="악기사진" />
       </li>
       <li className={cx('instrument-type')}>
-        <Text size="xlg">{type}</Text>
+        <Text size="lg">{type}</Text>
       </li>
       <li className={cx('instrument-sheet')}>
         <Text size="m" color="gray" weight="medium">

--- a/client/src/components/UI/molecules/InstrumentCard/InstrumentCard.tsx
+++ b/client/src/components/UI/molecules/InstrumentCard/InstrumentCard.tsx
@@ -1,4 +1,6 @@
 import classNames from 'classnames/bind';
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { ImgLayout, Text } from '../../atoms';
 import styles from './instrumentCard.module.scss';
 
@@ -10,21 +12,37 @@ interface InstrumentCardProps {
 
 const InstrumentCard = ({ src, type, sheets }: InstrumentCardProps) => {
   const cx = classNames.bind(styles);
+  const [instrumentName, setInstrumentName] = useState('');
+
+  useEffect(() => {
+    if (type === 'piano') setInstrumentName('피아노');
+    else if (type === 'electric') setInstrumentName('일렉 기타');
+    else if (type === 'acoustic') setInstrumentName('어쿠스틱 기타');
+    else if (type === 'bass') setInstrumentName('베이스');
+    else if (type === 'drum') setInstrumentName('드럼');
+  }, [instrumentName]);
 
   return (
-    <ul className={cx('instrument-card')}>
-      <li className={cx('instrument-img')}>
-        <ImgLayout shape="square" size="responsive" src={src} alt="악기사진" />
-      </li>
-      <li className={cx('instrument-type')}>
-        <Text size="lg">{type}</Text>
-      </li>
-      <li className={cx('instrument-sheet')}>
-        <Text size="m" color="gray" weight="medium">
-          {`악보 (${sheets})`}
-        </Text>
-      </li>
-    </ul>
+    <Link to={`/instrument/${type}`}>
+      <ul className={cx('instrument-card')}>
+        <li className={cx('instrument-img')}>
+          <ImgLayout
+            shape="square"
+            size="responsive"
+            src={src}
+            alt="악기사진"
+          />
+        </li>
+        <li className={cx('instrument-type')}>
+          <Text size="lg">{instrumentName}</Text>
+        </li>
+        <li className={cx('instrument-sheet')}>
+          <Text size="m" color="gray" weight="medium">
+            {`악보 (${sheets})`}
+          </Text>
+        </li>
+      </ul>
+    </Link>
   );
 };
 

--- a/client/src/components/UI/molecules/InstrumentCard/instrumentCard.module.scss
+++ b/client/src/components/UI/molecules/InstrumentCard/instrumentCard.module.scss
@@ -11,6 +11,7 @@
     text-align: left;
     border: 1px solid $gray-white;
     box-shadow: 0 0 12px rgba(0,0,0, .05);
+    cursor: pointer;
 
     .instrument-type {
         margin: #{20/$font-size}rem 0 5px;
@@ -19,4 +20,10 @@
     .instrument-type, .instrument-sheet {
         padding-left: 5px;
     } 
+
+    &:hover {
+        margin-top: -10px;
+        box-shadow: 0 0 12px 10px rgba(0,0,0, .05);
+        transition: all .1s ease-in;
+    }
 }

--- a/client/src/components/UI/molecules/InstrumentCard/instrumentCard.module.scss
+++ b/client/src/components/UI/molecules/InstrumentCard/instrumentCard.module.scss
@@ -2,13 +2,15 @@
 
 .instrument-card {
     width: 100%;
-    max-width: #{269/$font-size}rem;
+    max-width: #{272/$font-size}rem;
     display: flex;
     flex-direction: column;
     padding: #{20/$font-size}rem;
-    background-color: $gray-white;
-    border-radius: 1rem;
+    background-color: $white;
+    border-radius: 1.5rem;
     text-align: left;
+    border: 1px solid $gray-white;
+    box-shadow: 0 0 12px rgba(0,0,0, .05);
 
     .instrument-type {
         margin: #{20/$font-size}rem 0 5px;

--- a/client/src/components/UI/organisms/Header/Header.stories.tsx
+++ b/client/src/components/UI/organisms/Header/Header.stories.tsx
@@ -1,11 +1,9 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react';
-import { withRouter } from 'storybook-addon-react-router-v6';
 import Headers from './Header';
 
 export default {
   title: 'Organisms/Header',
   component: Headers,
-  decorators: [withRouter],
 } as ComponentMeta<typeof Headers>;
 
 const Template: ComponentStory<typeof Headers> = () => <Headers />;

--- a/client/src/components/UI/organisms/InstrumentLists/InstrumentLists.stories.tsx
+++ b/client/src/components/UI/organisms/InstrumentLists/InstrumentLists.stories.tsx
@@ -1,18 +1,13 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react';
-import InstrumentListss from './InstrumentLists';
+import InstrumentLists from './InstrumentLists';
 
 export default {
   title: 'Organisms/InstrumentLists',
-  component: InstrumentListss,
-} as ComponentMeta<typeof InstrumentListss>;
+  component: InstrumentLists,
+} as ComponentMeta<typeof InstrumentLists>;
 
-const Template: ComponentStory<typeof InstrumentListss> = (args) => (
-  <InstrumentListss {...args} />
+const Template: ComponentStory<typeof InstrumentLists> = () => (
+  <InstrumentLists />
 );
 
-export const InstrumentLists = Template.bind({});
-
-// Todo: 추후 props 형식에 따라 변경 예정
-InstrumentLists.args = {
-  arraylength: 6,
-};
+export const Default = Template.bind({});

--- a/client/src/components/UI/organisms/InstrumentLists/InstrumentLists.tsx
+++ b/client/src/components/UI/organisms/InstrumentLists/InstrumentLists.tsx
@@ -2,27 +2,21 @@ import styles from './instrumentLists.module.scss';
 import classNames from 'classnames/bind';
 import { InstrumentCard } from '../../molecules';
 
-// Todo: props는 추후 데이터 형식에 따라 변경
-interface InstrumentListsProps {
-  arraylength?: number;
-}
-
-const InstrumentLists = ({ arraylength = 5 }: InstrumentListsProps) => {
+const InstrumentLists = () => {
   const cx = classNames.bind(styles);
 
   return (
     <ul className={cx('instrument-lists')}>
-      {Array(arraylength)
-        .fill(0)
-        .map((el) => (
-          <li className={cx('instrument-list')} key={el}>
-            <InstrumentCard
-              src="https://images.unsplash.com/photo-1520523839897-bd0b52f945a0?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=2340&q=80"
-              type="피아노"
-              sheets="12"
-            />
-          </li>
-        ))}
+      {/* Todo: 데이터 연결 */}
+      {['piano', 'electric', 'acoustic', 'bass', 'drum'].map((el, idx) => (
+        <li className={cx('instrument-list')} key={idx}>
+          <InstrumentCard
+            src="https://images.unsplash.com/photo-1520523839897-bd0b52f945a0?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=2340&q=80"
+            type={el}
+            sheets="12"
+          />
+        </li>
+      ))}
     </ul>
   );
 };

--- a/client/src/components/UI/organisms/InstrumentLists/instrumentLists.module.scss
+++ b/client/src/components/UI/organisms/InstrumentLists/instrumentLists.module.scss
@@ -8,6 +8,6 @@
 
     .instrument-list{
         flex-basis: 25%;
-        padding: 0 #{18/$font-size}rem #{36/$font-size}rem;
+        padding: 0 1rem 2rem;
     }
 }

--- a/client/src/components/UI/organisms/MainSongSection/MainSongSection.tsx
+++ b/client/src/components/UI/organisms/MainSongSection/MainSongSection.tsx
@@ -24,7 +24,7 @@ function MainSongSection({
 }: MainSongSectionProps) {
   const cx = classNames.bind(styles);
   return (
-    <section>
+    <section className={cx('container')}>
       <SongTitle songTitle={songTitle} singer={singer} />
       <div className={cx('scorelist-wrapper')}>
         <MainScoreList

--- a/client/src/components/UI/organisms/MainSongSection/mainsongsection.module.scss
+++ b/client/src/components/UI/organisms/MainSongSection/mainsongsection.module.scss
@@ -1,6 +1,6 @@
 @import '/src/utils/utils';
 
-section {
+.container {
   display: flex;
   flex-direction: column;
   width: 100%;

--- a/client/src/components/pages/Instrument/Instrument.stories.tsx
+++ b/client/src/components/pages/Instrument/Instrument.stories.tsx
@@ -1,0 +1,11 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import Instrument from './Instrument';
+
+export default {
+  title: 'Pages/Instrument',
+  component: Instrument,
+} as ComponentMeta<typeof Instrument>;
+
+const Template: ComponentStory<typeof Instrument> = () => <Instrument />;
+
+export const Default = Template.bind({});

--- a/client/src/components/pages/Instrument/Instrument.tsx
+++ b/client/src/components/pages/Instrument/Instrument.tsx
@@ -1,0 +1,21 @@
+import classNames from 'classnames/bind';
+import { Text } from '../../UI/atoms';
+import { InstrumentLists } from '../../UI/organisms';
+import styles from './instrument.module.scss';
+
+const Instrument = () => {
+  const cx = classNames.bind(styles);
+
+  return (
+    <section className={cx('container')}>
+      <h2>
+        <Text size="txlg">악기별 악보</Text>
+      </h2>
+      <div>
+        <InstrumentLists />
+      </div>
+    </section>
+  );
+};
+
+export default Instrument;

--- a/client/src/components/pages/Instrument/instrument.module.scss
+++ b/client/src/components/pages/Instrument/instrument.module.scss
@@ -1,0 +1,20 @@
+@import '/src/utils/utils';
+
+.container {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-top: 3rem;
+    padding: 0 1.4rem;
+
+    h2, div {
+        width: 100%;
+        max-width: #{1220/$font-size}rem;
+    }
+
+    h2 {
+        padding-left: 1rem;
+        margin-bottom: 2rem;
+    }
+}

--- a/client/src/components/pages/index.ts
+++ b/client/src/components/pages/index.ts
@@ -1,3 +1,4 @@
 import Layout from './Layout/Layout';
+import Instrument from './Instrument/Instrument';
 
-export { Layout };
+export { Layout, Instrument };


### PR DESCRIPTION
- 악기 페이지의 pc 레이아웃, 스타일은 완성되었습니다!
- 간격 등 스타일을 좀 더 수정했고, hover 효과를 추가했습니다.
- 악기별 상세페이지 연결과 데이터 조회 로직 추가 예정입니다.

스토리북에서는 스토리북 기본 스타일때문에 엉망으로 보입니다😢