### PR TITLE
Feat: 악기 상세페이지 및 구성 요소 구현

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,5 +1,5 @@
 import { Route, Routes } from 'react-router-dom';
-import { Instrument, Layout } from './components/pages';
+import { Instrument, InstrumentDetail, Layout } from './components/pages';
 import { Main } from './components/pages';
 import { Auth, PostMusic } from './components/pages';
 import { BrowserRouter } from 'react-router-dom';
@@ -14,6 +14,7 @@ function App() {
           <Route path="/" element={<Layout />}>
             <Route index element={<Main />} />
             <Route path="instrument" element={<Instrument />} />
+            <Route path="instrument/:instType" element={<InstrumentDetail />} />
             <Route path="/postmusic" element={<PostMusic />} />
             {/* MainPage 등 */}
           </Route>

--- a/client/src/components/UI/molecules/EditOrDownButton/EditOrDownButton.stories.tsx
+++ b/client/src/components/UI/molecules/EditOrDownButton/EditOrDownButton.stories.tsx
@@ -1,0 +1,16 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import EditOrDownButton from './EditOrDownButton';
+
+export default {
+  title: 'Molecules/EditOrDownButton',
+  component: EditOrDownButton,
+} as ComponentMeta<typeof EditOrDownButton>;
+
+const Template: ComponentStory<typeof EditOrDownButton> = (args) => (
+  <EditOrDownButton {...args} />
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  event: 'edit',
+};

--- a/client/src/components/UI/molecules/EditOrDownButton/EditOrDownButton.tsx
+++ b/client/src/components/UI/molecules/EditOrDownButton/EditOrDownButton.tsx
@@ -1,0 +1,34 @@
+import { useNavigate } from 'react-router-dom';
+import { Button, Icon, Text } from '../../atoms';
+
+interface EditOrDownButtonProps {
+  event: 'edit' | 'download';
+}
+
+const EditOrDownButton = ({ event }: EditOrDownButtonProps) => {
+  if (event === 'edit') {
+    const navigate = useNavigate();
+
+    return (
+      // Todo: 경로 수정
+      <Button theme="secondary" size="xs" onClick={() => navigate('/edit')}>
+        <Text color="blue" size="s">
+          수정하기
+        </Text>
+      </Button>
+    );
+  } else {
+    // Todo: 다운로드 로직
+    const handleDownload = () => {
+      console.log('다운로드');
+    };
+
+    return (
+      <Button theme="secondary" size="xs" onClick={handleDownload}>
+        <Icon icon="MdOutlineFileDownload" color="green" size="s" />
+      </Button>
+    );
+  }
+};
+
+export default EditOrDownButton;

--- a/client/src/components/UI/molecules/GNB/Menu/GlobalMenu.tsx
+++ b/client/src/components/UI/molecules/GNB/Menu/GlobalMenu.tsx
@@ -1,28 +1,23 @@
 import styles from './globalmenu.module.scss';
 import classNames from 'classnames/bind';
 import { Icon, Text } from '../../../atoms';
-import { Link, useLocation } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
 const GlobalMenu = () => {
   const cx = classNames.bind(styles);
-  const { pathname } = useLocation();
 
   return (
     <ul className={cx('menu-lists')}>
-      <li className={cx('menu-list', pathname === '/' && 'active')}>
+      <li className={cx('menu-list')}>
         <Link to="/">
-          <Icon icon="MdOutlineQueueMusic" size="m" color="gray" />
-          <Text size="lg" color="gray">
-            곡
-          </Text>
+          <Icon icon="MdOutlineQueueMusic" />
+          <Text size="lg">곡</Text>
         </Link>
       </li>
-      <li className={cx('menu-list', pathname === '/instrument' && 'active')}>
+      <li className={cx('menu-list')}>
         <Link to="/instrument">
-          <Icon icon="MdPiano" size="s" color="gray" />
-          <Text size="lg" color="gray">
-            악기
-          </Text>
+          <Icon icon="MdPiano" size="s" />
+          <Text size="lg">악기</Text>
         </Link>
       </li>
     </ul>

--- a/client/src/components/UI/molecules/GNB/Menu/globalmenu.module.scss
+++ b/client/src/components/UI/molecules/GNB/Menu/globalmenu.module.scss
@@ -15,13 +15,9 @@
             }
         }
 
-        &.active {
-            span {
-                color: $black;
-                svg {
-                    fill: $black;
-                }
-            }
+        &:hover {
+            transform: scale(1.03);
+            transition: all .1s ease-in;
         }
     }
 }

--- a/client/src/components/UI/molecules/InstrumentCard/InstrumentCard.stories.tsx
+++ b/client/src/components/UI/molecules/InstrumentCard/InstrumentCard.stories.tsx
@@ -12,7 +12,8 @@ const Template: ComponentStory<typeof InstrumentCard> = (args) => (
 
 export const Default = Template.bind({});
 Default.args = {
-  src: 'https://images.unsplash.com/photo-1520523839897-bd0b52f945a0?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=2340&q=80',
   type: 'piano',
+  name: '피아노',
+  src: 'https://images.unsplash.com/photo-1520523839897-bd0b52f945a0?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=2340&q=80',
   sheets: '13',
 };

--- a/client/src/components/UI/molecules/InstrumentCard/InstrumentCard.tsx
+++ b/client/src/components/UI/molecules/InstrumentCard/InstrumentCard.tsx
@@ -1,26 +1,17 @@
 import classNames from 'classnames/bind';
-import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { ImgLayout, Text } from '../../atoms';
 import styles from './instrumentCard.module.scss';
 
 interface InstrumentCardProps {
-  src: string;
   type: string;
+  name: string;
+  src: string;
   sheets: string;
 }
 
-const InstrumentCard = ({ src, type, sheets }: InstrumentCardProps) => {
+const InstrumentCard = ({ type, name, src, sheets }: InstrumentCardProps) => {
   const cx = classNames.bind(styles);
-  const [instrumentName, setInstrumentName] = useState('');
-
-  useEffect(() => {
-    if (type === 'piano') setInstrumentName('피아노');
-    else if (type === 'electric') setInstrumentName('일렉 기타');
-    else if (type === 'acoustic') setInstrumentName('어쿠스틱 기타');
-    else if (type === 'bass') setInstrumentName('베이스');
-    else if (type === 'drum') setInstrumentName('드럼');
-  }, [instrumentName]);
 
   return (
     <Link to={`/instrument/${type}`}>
@@ -34,7 +25,7 @@ const InstrumentCard = ({ src, type, sheets }: InstrumentCardProps) => {
           />
         </li>
         <li className={cx('instrument-type')}>
-          <Text size="lg">{instrumentName}</Text>
+          <Text size="lg">{name}</Text>
         </li>
         <li className={cx('instrument-sheet')}>
           <Text size="m" color="gray" weight="medium">

--- a/client/src/components/UI/molecules/Pagination/Pagination.stories.tsx
+++ b/client/src/components/UI/molecules/Pagination/Pagination.stories.tsx
@@ -1,0 +1,17 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import Pagination from './Pagination';
+
+export default {
+  title: 'Molecules/Pagination',
+  component: Pagination,
+} as ComponentMeta<typeof Pagination>;
+
+const Template: ComponentStory<typeof Pagination> = (args) => (
+  <Pagination {...args} />
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  totalLists: 23,
+  currentPage: 1,
+};

--- a/client/src/components/UI/molecules/Pagination/Pagination.tsx
+++ b/client/src/components/UI/molecules/Pagination/Pagination.tsx
@@ -1,0 +1,91 @@
+import styles from './pagination.module.scss';
+import classNames from 'classnames/bind';
+import {
+  Dispatch,
+  MouseEvent,
+  SetStateAction,
+  useEffect,
+  useState,
+} from 'react';
+import { Icon } from '../../atoms';
+
+interface PaginationProps {
+  totalLists?: number;
+  currentPage?: number;
+  setCurrentPage?: Dispatch<SetStateAction<number>>;
+}
+
+const Pagination = ({
+  totalLists = 60,
+  currentPage = 7,
+  setCurrentPage,
+}: PaginationProps) => {
+  const cx = classNames.bind(styles);
+  const listPerpage = 5;
+  const totalPages = Math.ceil(totalLists / listPerpage);
+  const totalPageArr = Array(totalPages)
+    .fill(1)
+    .map((el, idx) => el + idx);
+  const [pageGroup, setPageGroup] = useState<number[]>([]);
+  const prevActive = pageGroup[0] !== 1;
+  const nextActive = pageGroup[pageGroup.length - 1] < totalPages;
+
+  useEffect(() => {
+    const pageGroupArr = totalPageArr.slice(
+      currentPage - 1 - ((currentPage - 1) % 5),
+      currentPage - 1 - ((currentPage - 1) % 5) + 5
+    );
+    setPageGroup([...pageGroupArr]);
+  }, [totalPages]);
+
+  const handlePrev = () => {
+    if (!prevActive) return;
+
+    // setIsPending(true);
+    // setCurrentPage(pageGroup[0] - 5);
+  };
+
+  const handlePage = (e: MouseEvent<HTMLButtonElement>) => {
+    if (Number((e.target as HTMLButtonElement).value) === currentPage) return;
+    // setIsPending(true);
+    // setCurrentPage(Number((e.target as HTMLButtonElement).value));
+  };
+
+  const handleNext = () => {
+    if (!nextActive) return;
+
+    // setIsPending(true);
+    // setCurrentPage(pageGroup[0] + 5);
+  };
+
+  return (
+    <div className={cx('buttons')}>
+      <button
+        className={cx('prev', prevActive && 'active')}
+        onClick={handlePrev}
+        disabled={!prevActive}
+      >
+        <Icon icon="MdKeyboardArrowLeft" color="gray" />
+      </button>
+      {pageGroup.map((el, idx) => (
+        <button
+          className={cx('page', el === currentPage && 'active')}
+          key={idx}
+          value={el}
+          onClick={handlePage}
+        >
+          {el}
+        </button>
+      ))}
+      <button
+        className={cx('next', nextActive && 'active')}
+        onClick={handleNext}
+        disabled={!nextActive}
+      >
+        <Icon icon="MdKeyboardArrowRight" color="gray" />
+      </button>
+    </div>
+  );
+};
+
+export default Pagination;

--- a/client/src/components/UI/molecules/Pagination/Pagination.tsx
+++ b/client/src/components/UI/molecules/Pagination/Pagination.tsx
@@ -10,52 +10,55 @@ import {
 import { Icon } from '../../atoms';
 
 interface PaginationProps {
-  totalLists?: number;
-  currentPage?: number;
-  setCurrentPage?: Dispatch<SetStateAction<number>>;
+  totalLists: number;
+  currentPage: number;
+  setCurrentPage: Dispatch<SetStateAction<number>>;
 }
 
 const Pagination = ({
-  totalLists = 60,
-  currentPage = 7,
+  totalLists,
+  currentPage,
   setCurrentPage,
 }: PaginationProps) => {
   const cx = classNames.bind(styles);
-  const listPerpage = 5;
+  const listPerpage = 1;
   const totalPages = Math.ceil(totalLists / listPerpage);
-  const totalPageArr = Array(totalPages)
-    .fill(1)
-    .map((el, idx) => el + idx);
+  let totalPageArr = [1];
+  if (totalPages > 1) {
+    totalPageArr = Array(totalPages)
+      .fill(1)
+      .map((el, idx) => el + idx);
+  }
   const [pageGroup, setPageGroup] = useState<number[]>([]);
   const prevActive = pageGroup[0] !== 1;
   const nextActive = pageGroup[pageGroup.length - 1] < totalPages;
 
   useEffect(() => {
     const pageGroupArr = totalPageArr.slice(
-      currentPage - 1 - ((currentPage - 1) % 5),
-      currentPage - 1 - ((currentPage - 1) % 5) + 5
+      currentPage - 1 - ((currentPage - 1) % 1),
+      currentPage - 1 - ((currentPage - 1) % 1) + 1
     );
     setPageGroup([...pageGroupArr]);
-  }, [totalPages]);
+  }, [currentPage]);
 
   const handlePrev = () => {
     if (!prevActive) return;
 
     // setIsPending(true);
-    // setCurrentPage(pageGroup[0] - 5);
+    setCurrentPage(pageGroup[0] - 1);
   };
 
   const handlePage = (e: MouseEvent<HTMLButtonElement>) => {
     if (Number((e.target as HTMLButtonElement).value) === currentPage) return;
     // setIsPending(true);
-    // setCurrentPage(Number((e.target as HTMLButtonElement).value));
+    setCurrentPage(Number((e.target as HTMLButtonElement).value));
   };
 
   const handleNext = () => {
     if (!nextActive) return;
 
     // setIsPending(true);
-    // setCurrentPage(pageGroup[0] + 5);
+    setCurrentPage(pageGroup[0] + 1);
   };
 
   return (

--- a/client/src/components/UI/molecules/Pagination/pagination.module.scss
+++ b/client/src/components/UI/molecules/Pagination/pagination.module.scss
@@ -1,0 +1,47 @@
+@import '/src/utils/utils';
+
+.buttons {
+    margin-top: 2rem;
+    display: flex;
+
+    button {
+        margin: 0 5px;
+        font-size: 1.2rem;
+        color: $gray;
+        border: none;
+        background: none;
+        border-radius: 1rem;
+        cursor: pointer;
+
+        &.active {
+            box-shadow: 0 4px 8px 0 rgba($black, .1);
+        }
+
+        &.page {
+            width: 3rem;
+            height: 3rem;
+
+            &:hover {
+                color: $light-green;
+                transition: all .1s ease-in;
+            }
+
+            &.active {
+                background-color: $light-green;
+                color: $white;
+            }
+
+        }
+
+        &.prev,
+        &.next {
+            padding: 5px 8px;
+            margin: 0 2rem;
+            cursor: not-allowed;
+
+            &.active {
+                cursor: pointer;
+            }
+        }
+    }
+}

--- a/client/src/components/UI/molecules/ScoreList/ScoreList.stories.tsx
+++ b/client/src/components/UI/molecules/ScoreList/ScoreList.stories.tsx
@@ -12,5 +12,12 @@ const Template: ComponentStory<typeof ScoreList> = (args) => (
 
 export const Default = Template.bind({});
 Default.args = {
-  buttonEvent: 'edit',
+  score: {
+    difficulty: '중간',
+    instType: '피아노',
+    songName: '오르트구름',
+    artist: '윤하',
+    author: 'lee',
+    price: '5000',
+  },
 };

--- a/client/src/components/UI/molecules/ScoreList/ScoreList.stories.tsx
+++ b/client/src/components/UI/molecules/ScoreList/ScoreList.stories.tsx
@@ -1,0 +1,16 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import ScoreList from './ScoreList';
+
+export default {
+  title: 'Molecules/ScoreList',
+  component: ScoreList,
+} as ComponentMeta<typeof ScoreList>;
+
+const Template: ComponentStory<typeof ScoreList> = (args) => (
+  <ScoreList {...args} />
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  btnType: 'text',
+};

--- a/client/src/components/UI/molecules/ScoreList/ScoreList.stories.tsx
+++ b/client/src/components/UI/molecules/ScoreList/ScoreList.stories.tsx
@@ -12,5 +12,5 @@ const Template: ComponentStory<typeof ScoreList> = (args) => (
 
 export const Default = Template.bind({});
 Default.args = {
-  btnType: 'text',
+  buttonEvent: 'edit',
 };

--- a/client/src/components/UI/molecules/ScoreList/ScoreList.tsx
+++ b/client/src/components/UI/molecules/ScoreList/ScoreList.tsx
@@ -1,15 +1,17 @@
 import classNames from 'classnames/bind';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { Text } from '../../atoms';
 import EditOrDownButton from '../EditOrDownButton/EditOrDownButton';
 import styles from './scoreList.module.scss';
 
 interface ScoreListProps {
-  btnType?: 'text' | 'edit' | 'download';
+  buttonEvent?: 'edit' | 'download';
 }
 
-const ScoreList = ({ btnType = 'text' }: ScoreListProps) => {
+// Todo: 데이터 연결
+const ScoreList = ({ buttonEvent = 'edit' }: ScoreListProps) => {
   const cx = classNames.bind(styles);
+  const { pathname } = useLocation();
 
   return (
     <div className={cx('wrapper')}>
@@ -37,13 +39,13 @@ const ScoreList = ({ btnType = 'text' }: ScoreListProps) => {
           </ul>
         </div>
       </Link>
-      {btnType === 'text' ? (
+      {!pathname.includes('/maypage') ? (
         <div className={cx('price')}>
           <Text color="blue">5000원</Text>
         </div>
       ) : (
         <div>
-          <EditOrDownButton event={btnType} />
+          <EditOrDownButton event={buttonEvent} />
         </div>
       )}
     </div>

--- a/client/src/components/UI/molecules/ScoreList/ScoreList.tsx
+++ b/client/src/components/UI/molecules/ScoreList/ScoreList.tsx
@@ -1,12 +1,19 @@
 import classNames from 'classnames/bind';
 import { Link } from 'react-router-dom';
 import { Text } from '../../atoms';
+import EditOrDownButton from '../EditOrDownButton/EditOrDownButton';
 import styles from './scoreList.module.scss';
 
-const ScoreList = () => {
+interface ScoreListProps {
+  btnType?: 'text' | 'edit' | 'download';
+}
+
+const ScoreList = ({ btnType = 'text' }: ScoreListProps) => {
   const cx = classNames.bind(styles);
+
   return (
     <div className={cx('wrapper')}>
+      {/* Todo: 경로 수정 */}
       <Link to="/scoredetail">
         <div className={cx('detail')}>
           <ul className={cx('score-song')}>
@@ -29,10 +36,16 @@ const ScoreList = () => {
             </li>
           </ul>
         </div>
+      </Link>
+      {btnType === 'text' ? (
         <div className={cx('price')}>
           <Text color="blue">5000원</Text>
         </div>
-      </Link>
+      ) : (
+        <div>
+          <EditOrDownButton event={btnType} />
+        </div>
+      )}
     </div>
   );
 };

--- a/client/src/components/UI/molecules/ScoreList/ScoreList.tsx
+++ b/client/src/components/UI/molecules/ScoreList/ScoreList.tsx
@@ -1,0 +1,40 @@
+import classNames from 'classnames/bind';
+import { Link } from 'react-router-dom';
+import { Text } from '../../atoms';
+import styles from './scoreList.module.scss';
+
+const ScoreList = () => {
+  const cx = classNames.bind(styles);
+  return (
+    <div className={cx('wrapper')}>
+      <Link to="/scoredetail">
+        <div className={cx('detail')}>
+          <ul className={cx('score-song')}>
+            <li>
+              <Text>KICK BACK (Chainsaw Man OP)</Text>
+            </li>
+            <li>
+              <Text color="gray">Kenshi Yonezu</Text>
+            </li>
+          </ul>
+          <ul className={cx('score-info')}>
+            <li>
+              <Text color="gray">Animenz</Text>
+            </li>
+            <li>
+              <Text color="gray">어쿠스틱 기타</Text>
+            </li>
+            <li>
+              <Text color="gray">어려움</Text>
+            </li>
+          </ul>
+        </div>
+        <div className={cx('price')}>
+          <Text color="blue">5000원</Text>
+        </div>
+      </Link>
+    </div>
+  );
+};
+
+export default ScoreList;

--- a/client/src/components/UI/molecules/ScoreList/ScoreList.tsx
+++ b/client/src/components/UI/molecules/ScoreList/ScoreList.tsx
@@ -1,47 +1,49 @@
 import classNames from 'classnames/bind';
+import { DocumentData } from 'firebase/firestore/lite';
 import { Link, useLocation } from 'react-router-dom';
 import { Text } from '../../atoms';
 import EditOrDownButton from '../EditOrDownButton/EditOrDownButton';
 import styles from './scoreList.module.scss';
 
 interface ScoreListProps {
+  score: DocumentData;
   buttonEvent?: 'edit' | 'download';
 }
 
-// Todo: 데이터 연결
-const ScoreList = ({ buttonEvent = 'edit' }: ScoreListProps) => {
+const ScoreList = ({ score, buttonEvent = 'edit' }: ScoreListProps) => {
   const cx = classNames.bind(styles);
   const { pathname } = useLocation();
+  const { artist, difficulty, instType, price, songName, author, scoreId } =
+    score;
 
   return (
     <div className={cx('wrapper')}>
-      {/* Todo: 경로 수정 */}
-      <Link to="/scoredetail">
+      <Link to={`/scoredetail/${scoreId}`}>
         <div className={cx('detail')}>
           <ul className={cx('score-song')}>
             <li>
-              <Text>KICK BACK (Chainsaw Man OP)</Text>
+              <Text>{songName}</Text>
             </li>
             <li>
-              <Text color="gray">Kenshi Yonezu</Text>
+              <Text color="gray">{artist}</Text>
             </li>
           </ul>
           <ul className={cx('score-info')}>
             <li>
-              <Text color="gray">Animenz</Text>
+              <Text color="gray">{author}</Text>
             </li>
             <li>
-              <Text color="gray">어쿠스틱 기타</Text>
+              <Text color="gray">{instType}</Text>
             </li>
             <li>
-              <Text color="gray">어려움</Text>
+              <Text color="gray">{difficulty}</Text>
             </li>
           </ul>
         </div>
       </Link>
       {!pathname.includes('/maypage') ? (
         <div className={cx('price')}>
-          <Text color="blue">5000원</Text>
+          <Text color="blue">{`${Number(price).toLocaleString()}원`}</Text>
         </div>
       ) : (
         <div>

--- a/client/src/components/UI/molecules/ScoreList/scoreList.module.scss
+++ b/client/src/components/UI/molecules/ScoreList/scoreList.module.scss
@@ -6,12 +6,12 @@
     margin-bottom: 10px;
     padding: 10px;
     border-radius: 10px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
 
     a {
         width: 100%;
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
 
         .detail {
             flex: 1;
@@ -49,13 +49,12 @@
             }
         }
 
-        .price {
-            width: 4rem;
-            text-align: center;
-        }
-
     }
 
+    .price {
+        min-width: #{85/$font-size}rem;
+        text-align: center;
+    }
 
     &:hover {
         background-color: $gray-white;

--- a/client/src/components/UI/molecules/ScoreList/scoreList.module.scss
+++ b/client/src/components/UI/molecules/ScoreList/scoreList.module.scss
@@ -1,0 +1,64 @@
+@import '/src/utils/utils';
+
+.wrapper {
+    width: 100%;
+    max-width: #{1220/$font-size}rem;
+    margin-bottom: 10px;
+    padding: 10px;
+    border-radius: 10px;
+
+    a {
+        width: 100%;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+
+        .detail {
+            flex: 1;
+            display: flex;
+            align-items: center;
+
+            .score-song {
+                flex-basis: 40%;
+                padding-left: 8px;
+            }
+
+            .score-info {
+                flex-basis: 60%;
+                display: flex;
+                justify-content: space-between;
+
+                li {
+                    flex-basis: 30%;
+
+                    &:first-child {
+                        flex-basis: 40%;
+                    }
+                }
+            }
+
+            li {
+                line-height: 1.5;
+                padding-right: 1rem;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                display: -webkit-box;
+                -webkit-line-clamp: 1;
+                -webkit-box-orient: vertical;
+                word-break: break-all;
+            }
+        }
+
+        .price {
+            width: 4rem;
+            text-align: center;
+        }
+
+    }
+
+
+    &:hover {
+        background-color: $gray-white;
+        transition: all .1s ease-in;
+    }
+}

--- a/client/src/components/UI/molecules/UserDropdown/UserMenu/UserMenu.tsx
+++ b/client/src/components/UI/molecules/UserDropdown/UserMenu/UserMenu.tsx
@@ -16,7 +16,7 @@ const UserMenu = () => {
     if (confirm('정말 로그아웃하시겠습니까?🥺')) {
       await auth.signOut();
       await persistor.purge();
-      navigate('/');
+      location.reload();
     }
   };
 

--- a/client/src/components/UI/molecules/index.ts
+++ b/client/src/components/UI/molecules/index.ts
@@ -10,6 +10,7 @@ import UserButton from './GNB/UserButton/UserButton';
 import UserAuthInput from './UserAuthInput/UserAuthInput';
 import PostInput from './PostInput/PostInput';
 import ScoreList from './ScoreList/ScoreList';
+import EditOrDownButton from './EditOrDownButton/EditOrDownButton';
 
 export {
   PostInput,
@@ -24,4 +25,5 @@ export {
   UserMenu,
   UserButton,
   ScoreList,
+  EditOrDownButton,
 };

--- a/client/src/components/UI/molecules/index.ts
+++ b/client/src/components/UI/molecules/index.ts
@@ -9,6 +9,7 @@ import UserMenu from './UserDropdown/UserMenu/UserMenu';
 import UserButton from './GNB/UserButton/UserButton';
 import UserAuthInput from './UserAuthInput/UserAuthInput';
 import PostInput from './PostInput/PostInput';
+import ScoreList from './ScoreList/ScoreList';
 
 export {
   PostInput,
@@ -22,4 +23,5 @@ export {
   MiniProfile,
   UserMenu,
   UserButton,
+  ScoreList,
 };

--- a/client/src/components/UI/molecules/index.ts
+++ b/client/src/components/UI/molecules/index.ts
@@ -11,6 +11,7 @@ import UserAuthInput from './UserAuthInput/UserAuthInput';
 import PostInput from './PostInput/PostInput';
 import ScoreList from './ScoreList/ScoreList';
 import EditOrDownButton from './EditOrDownButton/EditOrDownButton';
+import Pagination from './Pagination/Pagination';
 
 export {
   PostInput,
@@ -26,4 +27,5 @@ export {
   UserButton,
   ScoreList,
   EditOrDownButton,
+  Pagination,
 };

--- a/client/src/components/UI/organisms/CategoryDetail/CategoryDetail.module.scss
+++ b/client/src/components/UI/organisms/CategoryDetail/CategoryDetail.module.scss
@@ -1,0 +1,33 @@
+@import '/src/utils/utils';
+
+.cover-wrapper {
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 1.5rem 2.4rem;
+    background-color: #d9eddf;
+}
+.container {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 0 #{28.4/$font-size}rem;
+    margin-top: 3rem;
+
+    h2 {
+        width: 100%;
+        max-width: 1220px;
+        padding-left: 1rem;
+    }
+
+    .score-lists {
+        width: 100%;
+        max-width: 1220px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;   
+        margin-top: 1rem; 
+    }
+}

--- a/client/src/components/UI/organisms/CategoryDetail/CategoryDetail.stories.tsx
+++ b/client/src/components/UI/organisms/CategoryDetail/CategoryDetail.stories.tsx
@@ -1,0 +1,13 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import CategoryDetail from './CategoryDetail';
+
+export default {
+  title: 'Organisms/CategoryDetail',
+  component: CategoryDetail,
+} as ComponentMeta<typeof CategoryDetail>;
+
+const Template: ComponentStory<typeof CategoryDetail> = () => (
+  <CategoryDetail />
+);
+
+export const Default = Template.bind({});

--- a/client/src/components/UI/organisms/CategoryDetail/CategoryDetail.stories.tsx
+++ b/client/src/components/UI/organisms/CategoryDetail/CategoryDetail.stories.tsx
@@ -6,8 +6,16 @@ export default {
   component: CategoryDetail,
 } as ComponentMeta<typeof CategoryDetail>;
 
-const Template: ComponentStory<typeof CategoryDetail> = () => (
-  <CategoryDetail />
+const Template: ComponentStory<typeof CategoryDetail> = (args) => (
+  <CategoryDetail {...args} />
 );
 
 export const Default = Template.bind({});
+Default.args = {
+  scoresByInst: {
+    thumbnail:
+      'https://images.unsplash.com/photo-1520523839897-bd0b52f945a0?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=2340&q=80',
+    name: '피아노',
+    scores: [],
+  },
+};

--- a/client/src/components/UI/organisms/CategoryDetail/CategoryDetail.tsx
+++ b/client/src/components/UI/organisms/CategoryDetail/CategoryDetail.tsx
@@ -1,29 +1,45 @@
 import styles from './CategoryDetail.module.scss';
 import classNames from 'classnames/bind';
-import { CategoryCover, ScoreList } from '../../molecules';
+import { CategoryCover, Pagination, ScoreList } from '../../molecules';
 import { Text } from '../../atoms';
+import { useEffect, useState } from 'react';
+import { DocumentData } from 'firebase/firestore/lite';
 
-// Todo: 데이터 연결
-const CategoryDetail = () => {
+interface CategoryDetailProps {
+  scoresByInst: DocumentData;
+  totalLists: number;
+}
+
+const CategoryDetail = ({ scoresByInst, totalLists }: CategoryDetailProps) => {
   const cx = classNames.bind(styles);
+  const { thumbnail, name, scores } = scoresByInst;
+  const [scoresData, setScoresData] = useState<DocumentData>([]);
+  const [currentPage, setCurrentPage] = useState(1);
+
+  useEffect(() => {
+    const currentData = scores?.slice(currentPage - 1, currentPage + 0);
+    setScoresData(currentData);
+  }, [currentPage, scoresByInst]);
 
   return (
     <>
       <div className={cx('cover-wrapper')}>
-        <CategoryCover category="악기" thumbnail="piano" title="피아노" />
+        <CategoryCover category="악기" thumbnail={thumbnail} title={name} />
       </div>
       <section className={cx('container')}>
         <h2>
           <Text size="xlg">악보</Text>
         </h2>
         <div className={cx('score-lists')}>
-          {Array(10)
-            .fill(0)
-            .map((el, idx) => (
-              <ScoreList key={idx} />
-            ))}
+          {scoresData?.map((score: DocumentData, idx: number) => (
+            <ScoreList score={score} key={idx} />
+          ))}
         </div>
-        {/* 페이지네이션 */}
+        <Pagination
+          currentPage={currentPage}
+          setCurrentPage={setCurrentPage}
+          totalLists={totalLists}
+        />
       </section>
     </>
   );

--- a/client/src/components/UI/organisms/CategoryDetail/CategoryDetail.tsx
+++ b/client/src/components/UI/organisms/CategoryDetail/CategoryDetail.tsx
@@ -1,0 +1,32 @@
+import styles from './CategoryDetail.module.scss';
+import classNames from 'classnames/bind';
+import { CategoryCover, ScoreList } from '../../molecules';
+import { Text } from '../../atoms';
+
+// Todo: 데이터 연결
+const CategoryDetail = () => {
+  const cx = classNames.bind(styles);
+
+  return (
+    <>
+      <div className={cx('cover-wrapper')}>
+        <CategoryCover category="악기" thumbnail="piano" title="피아노" />
+      </div>
+      <section className={cx('container')}>
+        <h2>
+          <Text size="xlg">악보</Text>
+        </h2>
+        <div className={cx('score-lists')}>
+          {Array(10)
+            .fill(0)
+            .map((el, idx) => (
+              <ScoreList key={idx} />
+            ))}
+        </div>
+        {/* 페이지네이션 */}
+      </section>
+    </>
+  );
+};
+
+export default CategoryDetail;

--- a/client/src/components/UI/organisms/Header/Header.tsx
+++ b/client/src/components/UI/organisms/Header/Header.tsx
@@ -9,7 +9,6 @@ import { useNavigate } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 import { setHeader } from '../../../../redux/HeaderSlice';
 import { auth } from '../../../../firebase/firebase';
-import { useEffect } from '@storybook/addons';
 import { setUserInfo } from '../../../../redux/PostSlice';
 import { getMusicData } from '../../../../firebase/firebase';
 

--- a/client/src/components/UI/organisms/InstrumentLists/InstrumentLists.tsx
+++ b/client/src/components/UI/organisms/InstrumentLists/InstrumentLists.tsx
@@ -1,18 +1,20 @@
 import styles from './instrumentLists.module.scss';
 import classNames from 'classnames/bind';
 import { InstrumentCard } from '../../molecules';
+import { instrumentDummy } from './instrumentDummy';
 
 const InstrumentLists = () => {
   const cx = classNames.bind(styles);
 
   return (
     <ul className={cx('instrument-lists')}>
-      {/* Todo: 데이터 연결 */}
-      {['piano', 'electric', 'acoustic', 'bass', 'drum'].map((el, idx) => (
+      {/* Todo: 악보 개수 데이터 연결 */}
+      {instrumentDummy.map((el, idx) => (
         <li className={cx('instrument-list')} key={idx}>
           <InstrumentCard
-            src="https://images.unsplash.com/photo-1520523839897-bd0b52f945a0?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=2340&q=80"
-            type={el}
+            type={el.type}
+            name={el.name}
+            src={el.thumbnail}
             sheets="12"
           />
         </li>

--- a/client/src/components/UI/organisms/InstrumentLists/instrumentDummy.ts
+++ b/client/src/components/UI/organisms/InstrumentLists/instrumentDummy.ts
@@ -1,0 +1,33 @@
+export const instrumentDummy = [
+  {
+    type: 'piano',
+    name: '피아노',
+    thumbnail:
+      'https://images.unsplash.com/photo-1520523839897-bd0b52f945a0?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=2340&q=80',
+  },
+
+  {
+    type: 'electric',
+    name: '일렉 기타',
+    thumbnail:
+      'https://images.unsplash.com/photo-1586391159312-e26d25fa4c42?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1035&q=80',
+  },
+  {
+    type: 'acoustic',
+    name: '어쿠스틱 기타',
+    thumbnail:
+      'https://images.unsplash.com/photo-1541689592655-f5f52825a3b8?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxzZWFyY2h8OHx8YWNvdXN0aWMlMjBndWl0YXJ8ZW58MHx8MHx8&auto=format&fit=crop&w=800&q=60',
+  },
+  {
+    type: 'bass',
+    name: '베이스',
+    thumbnail:
+      'https://images.unsplash.com/photo-1609254757493-26972cd14571?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxzZWFyY2h8Mzh8fGJhc3N8ZW58MHx8MHx8&auto=format&fit=crop&w=800&q=60',
+  },
+  {
+    type: 'drum',
+    name: '드럼',
+    thumbnail:
+      'https://images.unsplash.com/photo-1524230659092-07f99a75c013?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxzZWFyY2h8Mnx8ZHJ1bXxlbnwwfHwwfHw%3D&auto=format&fit=crop&w=800&q=60',
+  },
+];

--- a/client/src/components/UI/organisms/UserAuth/UserAuth.tsx
+++ b/client/src/components/UI/organisms/UserAuth/UserAuth.tsx
@@ -33,7 +33,6 @@ const UserAuth = ({ type }: UserAuthProps) => {
       await handleUserLogin(userLoginData.email, userLoginData.password).then(
         (response) => {
           if (typeof response !== 'undefined') {
-            console.log(response);
             const { displayName, email, phoneNumber, photoURL } = response;
             dispatch(userInfo({ displayName, email, phoneNumber, photoURL }));
           }
@@ -45,7 +44,12 @@ const UserAuth = ({ type }: UserAuthProps) => {
         userRegData.email,
         userRegData.password,
         userRegData.nickname
-      );
+      ).then((response) => {
+        if (typeof response !== 'undefined') {
+          const { displayName, email, phoneNumber, photoURL } = response;
+          dispatch(userInfo({ displayName, email, phoneNumber, photoURL }));
+        }
+      });
       navigate('/');
     } else null;
   };

--- a/client/src/components/UI/organisms/UserAuth/UserAuth.tsx
+++ b/client/src/components/UI/organisms/UserAuth/UserAuth.tsx
@@ -55,7 +55,12 @@ const UserAuth = ({ type }: UserAuthProps) => {
   };
 
   const handleOauth = async () => {
-    await handleGoogleLogin();
+    await handleGoogleLogin().then((response) => {
+      if (typeof response !== 'undefined') {
+        const { displayName, email, phoneNumber, photoURL } = response;
+        dispatch(userInfo({ displayName, email, phoneNumber, photoURL }));
+      }
+    });
     navigate('/');
   };
 

--- a/client/src/components/UI/organisms/index.ts
+++ b/client/src/components/UI/organisms/index.ts
@@ -6,7 +6,7 @@ import MainSongSection from './MainSongSection/MainSongSection';
 import UserAuth from './UserAuth/UserAuth';
 import MainGrid from './MainGrid/MainGrid';
 import Carousel from './Carousel/Carousel';
-
+import CategoryDetail from './CategoryDetail/CategoryDetail';
 export {
   UserAuth,
   InstrumentLists,
@@ -16,4 +16,5 @@ export {
   MainSongSection,
   MainGrid,
   Carousel,
+  CategoryDetail,
 };

--- a/client/src/components/pages/InstrumentDetail/InstrumentDetail.stories.tsx
+++ b/client/src/components/pages/InstrumentDetail/InstrumentDetail.stories.tsx
@@ -1,0 +1,13 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import InstrumentDetail from './InstrumentDetail';
+
+export default {
+  title: 'Pages/InstrumentDetail',
+  component: InstrumentDetail,
+} as ComponentMeta<typeof InstrumentDetail>;
+
+const Template: ComponentStory<typeof InstrumentDetail> = () => (
+  <InstrumentDetail />
+);
+
+export const Default = Template.bind({});

--- a/client/src/components/pages/InstrumentDetail/InstrumentDetail.tsx
+++ b/client/src/components/pages/InstrumentDetail/InstrumentDetail.tsx
@@ -1,0 +1,24 @@
+import { DocumentData } from 'firebase/firestore/lite';
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { getScoresByInstrument } from '../../../firebase/firebase';
+import { CategoryDetail } from '../../UI/organisms';
+
+const InstrumentDetail = () => {
+  const [scoresByInst, setScoresByInst] = useState<DocumentData>({});
+  const [totalLists, setTotalLists] = useState(0);
+  const { instType } = useParams();
+
+  useEffect(() => {
+    getScoresByInstrument(`${instType}`)
+      .then((data) => {
+        setScoresByInst(data);
+        setTotalLists(data.scores.length);
+      })
+      .catch((error) => console.log(error));
+  }, []);
+
+  return <CategoryDetail scoresByInst={scoresByInst} totalLists={totalLists} />;
+};
+
+export default InstrumentDetail;

--- a/client/src/components/pages/index.ts
+++ b/client/src/components/pages/index.ts
@@ -3,4 +3,6 @@ import Instrument from './Instrument/Instrument';
 import Auth from './Auth/Auth';
 import PostMusic from './PostMusic/PostMusic';
 import Main from './Main/Main';
-export { Layout, Instrument, Auth, PostMusic, Main };
+import InstrumentDetail from './InstrumentDetail/InstrumentDetail';
+
+export { Layout, Instrument, Auth, PostMusic, Main, InstrumentDetail };

--- a/client/src/firebase/firebase.tsx
+++ b/client/src/firebase/firebase.tsx
@@ -1,13 +1,6 @@
 // Import the functions you need from the SDKs you need
 
 import { initializeApp } from 'firebase/app';
-import {
-  getFirestore,
-  collection,
-  getDocs,
-  doc,
-  getDoc,
-} from 'firebase/firestore/lite';
 import { getAuth, GoogleAuthProvider } from 'firebase/auth';
 import { getStorage, ref, uploadBytes } from 'firebase/storage';
 import {

--- a/client/src/firebase/firebase.tsx
+++ b/client/src/firebase/firebase.tsx
@@ -1,7 +1,13 @@
 // Import the functions you need from the SDKs you need
 
 import { initializeApp } from 'firebase/app';
-import { getFirestore, collection, getDocs } from 'firebase/firestore/lite';
+import {
+  getFirestore,
+  collection,
+  getDocs,
+  doc,
+  getDoc,
+} from 'firebase/firestore/lite';
 import { getAuth, GoogleAuthProvider } from 'firebase/auth';
 import { DocumentData } from 'firebase/firestore/lite';
 
@@ -32,6 +38,16 @@ export async function getMusics() {
   const snapshot = await getDocs(ref);
   const list = snapshot.docs.map((doc: DocumentData) => doc.data());
   return list;
+}
+
+export async function getScoresByInstrument(docName: string) {
+  const ref = doc(db, 'instrument', docName);
+  const snapshot = await getDoc(ref);
+
+  if (snapshot.exists()) {
+    return snapshot.data();
+  }
+  return {};
 }
 
 export const auth = getAuth();

--- a/client/src/redux/UserSlice.tsx
+++ b/client/src/redux/UserSlice.tsx
@@ -1,5 +1,4 @@
 import { createSlice, PayloadAction, Reducer } from '@reduxjs/toolkit';
-import { toast } from 'react-toastify';
 import { PURGE } from 'redux-persist';
 
 interface StateType {
@@ -31,7 +30,6 @@ export const userSlice = createSlice({
       initialState;
       localStorage.removeItem('authorization');
       localStorage.removeItem('refresh');
-      toast.success('다음에 또 만나요👋');
     });
   },
 });

--- a/client/src/utils/ApiCollection/User.tsx
+++ b/client/src/utils/ApiCollection/User.tsx
@@ -53,13 +53,17 @@ export const handleRegisterUser = async (
 };
 
 export const handleGoogleLogin = async () => {
+  let response;
   await signInWithPopup(auth, provider)
     .then((data) => {
       const credential = GoogleAuthProvider.credentialFromResult(data);
       const token = credential?.accessToken;
       const user = data.user;
+      response = user;
       if (token) localStorage.setItem('authorization', token);
       if (user.refreshToken) localStorage.setItem('refresh', user.refreshToken);
     })
     .catch((err) => console.log(err));
+
+  return response;
 };

--- a/client/src/utils/ApiCollection/User.tsx
+++ b/client/src/utils/ApiCollection/User.tsx
@@ -17,7 +17,6 @@ export const handleUserLogin = async (email: any, password: any) => {
       localStorage.setItem('authorization', user.uid);
       localStorage.setItem('refresh', user.refreshToken);
       response = user;
-      console.log(user);
       // ...
     })
 
@@ -35,25 +34,22 @@ export const handleRegisterUser = async (
   password: any,
   nickname: any
 ) => {
-  let response;
   await createUserWithEmailAndPassword(auth, email, password)
     .then((userCredential) => {
       // Signed in
       const user = userCredential.user;
-      localStorage.setItem('authorization', user.uid);
-      localStorage.setItem('refresh', user.refreshToken);
+
       updateProfile(user, {
         displayName: nickname,
         photoURL: Avatar(),
       });
-      // ...
     })
-
     .catch((error) => {
-      response = error;
-      console.log(response.code);
+      console.log(error.code);
       // if 400 => switch and show user that the ac already exists
     });
+
+  return handleUserLogin(email, password);
 };
 
 export const handleGoogleLogin = async () => {


### PR DESCRIPTION
ScoreList Molecule
--
- 악기 상세페이지, 곡 상세페이지, 마이페이지에서 활용 가능!
- `가격, 수정 버튼, 다운 버튼` 중 페이지에서 요구되는 타입으로 사용할 수 있습니다. (아직 버튼의 기능은 구현되지 않았습니다.)

Pagination Molecule
--
- 현재는 1페이지당 1개의 데이터를 보여주도록 되어있고, 페이지그룹 또한 한페이지씩 보이도록 되어있습니다. 
데이터를 좀 만들고 나면 1페이지당 5개의 데이터와, 5페이지그룹으로 수정할 예정입니다.

InstrumentDetail Page, CategoryDetail Organism
--
- 악기 상세페이지, 악기 상세페이지와 곡 상세페이지를 구성하는 CategoryDetail Organism을 구현하였습니다.
- 악보 데이터 연결😇

etc
--
- 악기별 악보 페이지의 악기 데이터는 파이어베이스에서 가져오지 않고 더미데이터에서 가져옵니다.
- 이 외 짜잘한 수정 몇가지

📍 scoreId와 악기별 악보 페이지의 악보 개수에 대해 의논이 필요할 것 같습니다..😢

## 끝!!🤨