### PR TITLE
Feat: 악보 등록페이지 api 리펙토링

### DIFF
--- a/client/src/components/UI/molecules/PostInput/PostInput.tsx
+++ b/client/src/components/UI/molecules/PostInput/PostInput.tsx
@@ -3,12 +3,10 @@ import { Input, Text, Icon, ImgLayout, Button } from '../../atoms';
 import { useState } from 'react';
 import classNames from 'classnames/bind';
 import styles from './postInput.module.scss';
-
 import {
   getSearchData,
   refreshToken,
 } from '../../../../utils/ApiCollection/SearchData';
-
 import { useDispatch } from 'react-redux';
 import {
   setPrice,

--- a/client/src/components/UI/molecules/PostSidebar/PostSidebar.tsx
+++ b/client/src/components/UI/molecules/PostSidebar/PostSidebar.tsx
@@ -2,52 +2,42 @@ import React, { useState, useRef, useEffect } from 'react';
 import styles from './postSidebar.module.scss';
 import classNames from 'classnames/bind';
 import { Button, Icon, Text } from '../../atoms';
+import { useDispatch } from 'react-redux';
+import { setFile } from '../../../../redux/FileSlice';
+import { postPDF } from '../../../../firebase/firebase';
+import { setDownloadURL } from '../../../../redux/PostSlice';
 
 const PostSidebar = () => {
+  const dispatch = useDispatch();
   const cx = classNames.bind(styles);
   const [fileName, setFileName] = useState('');
-  const [uploadProgress, setUploadProgress] = useState(0);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  const handleFileUpload = (e: any) => {
+  const handleFileUpload = async (e: any) => {
     if (e.target.files.length > 0) {
       const [file] = e.target.files;
       if (file.type === 'application/pdf') {
-        const fileBlob = new Blob([file], { type: file.type });
+        try {
+          const sheetURL = await postPDF(file);
+          dispatch(setDownloadURL(sheetURL));
+        } catch (err) {
+          console.log(err);
+        }
         setFileName(file.name);
       } else {
         alert('Only .pdf files are supported.');
       }
+
+      dispatch(setFile(file));
     }
   };
-
-  // const uploadFirebase = async (fileBlob: Blob, fileName: string) => {
-  //   const uploadTask = uploadBytesResumable(sheetRef, fileBlob);
-
-  //   uploadTask.on(
-  //     'state_changed',
-  //     (snapshot: any) => {
-  //       setUploadProgress(
-  //         (snapshot.bytesTransferred / snapshot.totalBytes) * 100
-  //       );
-  //     },
-  //     (error: any) => {
-  //       console.error(error);
-  //     },
-  //     () => {
-  //       console.log('File successfully uploaded to Firebase!');
-  //     }
-  //   );
-  // };
 
   const handleButtonClick = () => {
     if (fileInputRef.current) {
       fileInputRef.current.click();
-      console.log(fileInputRef.current, fileName);
     }
   };
   useEffect(() => {
-    console.log(fileInputRef.current, fileName);
     if (!fileName && fileInputRef.current) {
       fileInputRef.current.value = '';
     }
@@ -79,7 +69,7 @@ const PostSidebar = () => {
               ref={fileInputRef}
               type="file"
               style={{ display: 'none' }}
-              onChange={handleFileUpload}
+              onChange={(e) => handleFileUpload(e)}
               accept="application/pdf"
             />
           </div>

--- a/client/src/components/UI/organisms/Header/Header.tsx
+++ b/client/src/components/UI/organisms/Header/Header.tsx
@@ -8,7 +8,7 @@ import { RootState } from '../../../../redux/store';
 import { useNavigate } from 'react-router-dom';
 import { setHeader } from '../../../../redux/HeaderSlice';
 import { auth, getMusicData } from '../../../../firebase/firebase';
-import { setUserInfo } from '../../../../redux/PostSlice';
+import { setUserInfo, initializeState } from '../../../../redux/PostSlice';
 import { toast } from 'react-toastify';
 
 const Header = () => {
@@ -22,6 +22,7 @@ const Header = () => {
 
   const handleIsPost = () => {
     dispatch(setHeader(false));
+    dispatch(initializeState());
     navigate(-1);
   };
 

--- a/client/src/components/UI/organisms/Header/Header.tsx
+++ b/client/src/components/UI/organisms/Header/Header.tsx
@@ -18,8 +18,9 @@ const Header = () => {
   const headerState = useSelector(
     (state: RootState) => state.postHeader.isPost
   );
-  const data = useSelector((state: RootState) => state.PostInfo);
-
+  const data = useSelector((state: RootState) => state.postInfo);
+  const pdf = useSelector((state: RootState) => state.pdfFile);
+  console.log(data);
   const handleIsPost = () => {
     dispatch(setHeader(false));
     dispatch(initializeState());
@@ -40,7 +41,8 @@ const Header = () => {
       !scores[0].difficulty ||
       !scores[0].sheetType ||
       !scores[0].detail ||
-      !scores[0].price
+      !scores[0].price ||
+      !pdf
     ) {
       return false;
     }
@@ -50,9 +52,7 @@ const Header = () => {
   const handleUpload = async () => {
     if (!validateInputs()) {
       toast.error('모든 필드를 입력해주세요.');
-      return;
     }
-
     await getMusicData(data.songName, data).then(() => navigate('/'));
     dispatch(setHeader(false));
     toast.success('악보 등록 성공!');

--- a/client/src/components/UI/organisms/Header/Header.tsx
+++ b/client/src/components/UI/organisms/Header/Header.tsx
@@ -9,6 +9,7 @@ import { useNavigate } from 'react-router-dom';
 import { setHeader } from '../../../../redux/HeaderSlice';
 import { auth, getMusicData } from '../../../../firebase/firebase';
 import { setUserInfo } from '../../../../redux/PostSlice';
+import { toast } from 'react-toastify';
 
 const Header = () => {
   const cx = classNames.bind(styles);
@@ -28,9 +29,32 @@ const Header = () => {
     const user = [auth.currentUser.displayName, auth.currentUser.uid];
     dispatch(setUserInfo(user));
   }
+  const validateInputs = () => {
+    const { songName, artist, albumImg, scores } = data;
+    if (
+      !songName ||
+      !artist ||
+      !albumImg ||
+      !scores[0].instType ||
+      !scores[0].difficulty ||
+      !scores[0].sheetType ||
+      !scores[0].detail ||
+      !scores[0].price
+    ) {
+      return false;
+    }
+    return true;
+  };
+
   const handleUpload = async () => {
+    if (!validateInputs()) {
+      toast.error('모든 필드를 입력해주세요.');
+      return;
+    }
+
     await getMusicData(data.songName, data).then(() => navigate('/'));
     dispatch(setHeader(false));
+    toast.success('악보 등록 성공!');
   };
 
   if (headerState) {

--- a/client/src/components/UI/organisms/Header/Header.tsx
+++ b/client/src/components/UI/organisms/Header/Header.tsx
@@ -3,15 +3,12 @@ import classNames from 'classnames/bind';
 import { GlobalMenu } from '../../molecules';
 import UtilityMenu from '../UtilityMenu/UtilityMenu';
 import { Button, Icon, Logo, Text } from '../../atoms';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import { RootState } from '../../../../redux/store';
 import { useNavigate } from 'react-router-dom';
-import { useDispatch } from 'react-redux';
 import { setHeader } from '../../../../redux/HeaderSlice';
-import { auth } from '../../../../firebase/firebase';
-import { useEffect } from '@storybook/addons';
+import { auth, getMusicData } from '../../../../firebase/firebase';
 import { setUserInfo } from '../../../../redux/PostSlice';
-import { getMusicData } from '../../../../firebase/firebase';
 
 const Header = () => {
   const cx = classNames.bind(styles);
@@ -27,11 +24,13 @@ const Header = () => {
     navigate(-1);
   };
 
-  console.log(data);
-  const handleUpload = async () => {
-    const user = [auth.currentUser?.displayName, auth.currentUser?.uid];
+  if (auth.currentUser) {
+    const user = [auth.currentUser.displayName, auth.currentUser.uid];
     dispatch(setUserInfo(user));
+  }
+  const handleUpload = async () => {
     await getMusicData(data.songName, data).then(() => navigate('/'));
+    dispatch(setHeader(false));
   };
 
   if (headerState) {

--- a/client/src/components/UI/organisms/UserAuth/UserAuth.tsx
+++ b/client/src/components/UI/organisms/UserAuth/UserAuth.tsx
@@ -12,7 +12,7 @@ import {
 } from '../../../../utils/utils';
 import { useNavigate } from 'react-router-dom';
 import { userInfo } from '../../../../redux/UserSlice';
-
+import { toast } from 'react-toastify';
 interface UserAuthProps {
   type: 'Login' | 'SignUp';
 }
@@ -36,7 +36,7 @@ const UserAuth = ({ type }: UserAuthProps) => {
           }
         }
       );
-      navigate(-1);
+      navigate('/');
     } else if (typeState === 'SignUp') {
       await handleRegisterUser(
         userRegData.email,

--- a/client/src/components/UI/organisms/UserAuth/UserAuth.tsx
+++ b/client/src/components/UI/organisms/UserAuth/UserAuth.tsx
@@ -1,9 +1,8 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { Button, Icon, Logo, Text } from '../../atoms';
 import { UserAuthInput } from '../../molecules';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import { RootState } from '../../../../redux/store';
-import React from 'react';
 import classNames from 'classnames/bind';
 import styles from './userAuth.module.scss';
 import {
@@ -12,8 +11,6 @@ import {
   handleGoogleLogin,
 } from '../../../../utils/utils';
 import { useNavigate } from 'react-router-dom';
-import { Link } from 'react-router-dom';
-import { useDispatch } from 'react-redux';
 import { userInfo } from '../../../../redux/UserSlice';
 
 interface UserAuthProps {
@@ -60,13 +57,6 @@ const UserAuth = ({ type }: UserAuthProps) => {
       <div className={cx('userAuth')}>
         <div className={cx('userAuth__logo')}>
           <Logo type="mobile" />
-
-          {/* <img src={require('../../../../assets/Logo.png')} />
-        </div>
-        <div className={cx('logo__Text')}>
-          <Link to="/">
-            <span>악보의 정원</span>
-          </Link> */}
         </div>
         <UserAuthInput type="Login" placeholder="이메일"></UserAuthInput>
         <UserAuthInput type="Login" placeholder="비밀번호"></UserAuthInput>
@@ -111,12 +101,6 @@ const UserAuth = ({ type }: UserAuthProps) => {
       <div className={cx('userAuth')}>
         <div className={cx('userAuth__logo')}>
           <Logo type="mobile" />
-          {/* <img src={require('../../../../assets/Logo.png')} />
-        </div>
-        <div className={cx('logo__Text')}>
-          <Link to="/">
-            <span>악보의 정원</span>
-          </Link> */}
         </div>
 
         <UserAuthInput type="SignUp" placeholder="이메일"></UserAuthInput>

--- a/client/src/components/pages/PostMusic/PostMusic.tsx
+++ b/client/src/components/pages/PostMusic/PostMusic.tsx
@@ -1,10 +1,9 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import classNames from 'classnames/bind';
 import styles from './PostMusic.module.scss';
 import { DropDown, TextEditor, PostSidebar } from '../../UI/molecules';
 import { PostButtons, MusicPostInfo } from '../../UI/organisms';
-import { toast } from 'react-toastify';
 import { auth } from '../../../firebase/firebase';
 import { useNavigate } from 'react-router-dom';
 

--- a/client/src/components/pages/PostMusic/PostMusic.tsx
+++ b/client/src/components/pages/PostMusic/PostMusic.tsx
@@ -2,16 +2,8 @@ import React from 'react';
 
 import classNames from 'classnames/bind';
 import styles from './PostMusic.module.scss';
-import {
-  DropDown,
-  PostInput,
-  TextEditor,
-  PostSidebar,
-} from '../../UI/molecules';
+import { DropDown, TextEditor, PostSidebar } from '../../UI/molecules';
 import { PostButtons, MusicPostInfo } from '../../UI/organisms';
-
-import { useSelector } from 'react-redux';
-import { RootState } from '../../../redux/store';
 
 const PostMusic = () => {
   const cx = classNames.bind(styles);

--- a/client/src/components/pages/PostMusic/PostMusic.tsx
+++ b/client/src/components/pages/PostMusic/PostMusic.tsx
@@ -1,12 +1,22 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import classNames from 'classnames/bind';
 import styles from './PostMusic.module.scss';
 import { DropDown, TextEditor, PostSidebar } from '../../UI/molecules';
 import { PostButtons, MusicPostInfo } from '../../UI/organisms';
+import { toast } from 'react-toastify';
+import { auth } from '../../../firebase/firebase';
+import { useNavigate } from 'react-router-dom';
 
 const PostMusic = () => {
   const cx = classNames.bind(styles);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!auth.currentUser) {
+      navigate('/auth');
+    }
+  }, []);
 
   return (
     <div className={cx('wrapper')}>

--- a/client/src/firebase/firebase.tsx
+++ b/client/src/firebase/firebase.tsx
@@ -33,6 +33,8 @@ const firebaseConfig = {
 // Initialize Firebase
 const app = initializeApp(firebaseConfig);
 const db = getFirestore(app);
+export const auth = getAuth();
+export const provider = new GoogleAuthProvider();
 
 export async function getDocument() {
   const ref = collection(db, 'test');
@@ -57,14 +59,6 @@ export async function getScoresByInstrument(docName: string) {
   }
   return {};
 }
-
-// export async function getMusic(songName: string) {
-//   const ref = doc(db, 'test', songName);
-//   const snapshot = await getDoc(ref);
-//   console.log(snapshot.data());
-//   return snapshot.data();
-// }
-
 export async function getMusicData(songName: string, data: StateType) {
   const name = `${songName}-${data.artist}`;
   const info = doc(db, 'music', name);
@@ -133,6 +127,15 @@ async function postData(songName: string, data: StateType) {
 
   const instRef = doc(db, 'instrument', inst);
   await updateDoc(instRef, { scores: arrayUnion(data.scores[0]) });
+
+  const user = auth.currentUser;
+
+  // if (user) {
+  //   const uid = user.uid;
+  //   const purchasedScore = data.scores[0];
+  //   const userRef = doc(db, 'user', uid);
+  //   await setDoc(userRef, purchasedScore);
+  // }
 }
 
 /** 해당 곡으로 만들어진 문서가 존재한다면 아래 함수가 작동하여 scores 배열을 업데이트 합니다 */
@@ -161,11 +164,18 @@ async function updateData(songName: string, data: StateType) {
 
   const instRef = doc(db, 'instrument', inst);
   await updateDoc(instRef, { scores: arrayUnion(data.scores[0]) });
+
+  const user = auth.currentUser;
+
+  // if (user) {
+  //   const uid = user.uid;
+  //   const purchasedScore = data.scores[0];
+  //   const userRef = doc(db, 'user', uid);
+  //   await updateDoc(userRef, { purchasedList: arrayUnion(purchasedScore) });
+  // }
 }
 
-export const auth = getAuth();
-export const provider = new GoogleAuthProvider();
-
+/** 악보파일 업로드 api 호출 */
 export async function postPDF(file: any) {
   return new Promise<string>((resolve, reject) => {
     const storage = getStorage();

--- a/client/src/firebase/firebase.tsx
+++ b/client/src/firebase/firebase.tsx
@@ -1,7 +1,12 @@
 // Import the functions you need from the SDKs you need
 
 import { initializeApp } from 'firebase/app';
-import { getAuth, GoogleAuthProvider } from 'firebase/auth';
+import {
+  getAuth,
+  GoogleAuthProvider,
+  updatePhoneNumber,
+  updateProfile,
+} from 'firebase/auth';
 import { getStorage, ref, uploadBytes } from 'firebase/storage';
 import {
   getFirestore,
@@ -32,8 +37,6 @@ const firebaseConfig = {
 const app = initializeApp(firebaseConfig);
 const db = getFirestore(app);
 
-// Get a list of cities from your database
-
 export async function getDocument() {
   const ref = collection(db, 'test');
   const snapshot = await getDocs(ref);
@@ -57,11 +60,11 @@ export async function getMusics() {
 
 export async function getMusicData(songName: string, data: StateType) {
   const name = `${songName}-${data.artist}`;
-  const info = doc(db, 'test', name);
+  const info = doc(db, 'music', name);
   const infoSnapshot = await getDoc(info);
   const savedData = infoSnapshot.data();
 
-  const colRef = collection(db, 'test');
+  const colRef = collection(db, 'music');
   const colSnap = await getDocs(colRef);
 
   const list = colSnap.docs.map((doc: DocumentData) => doc.data());
@@ -116,7 +119,7 @@ export async function getMusicData(songName: string, data: StateType) {
 
 /** 해당 곡으로 만들어진 문서가 없으면 아래 함수가 작동하여 initialize 됩니다*/
 async function postData(songName: string, data: StateType) {
-  const infoRef = doc(db, 'test', songName);
+  const infoRef = doc(db, 'music', songName);
   await setDoc(infoRef, data);
 
   /** instrument collection 에 추가 */
@@ -144,7 +147,7 @@ async function postData(songName: string, data: StateType) {
 
 /** 해당 곡으로 만들어진 문서가 존재한다면 아래 함수가 작동하여 scores 배열을 업데이트 합니다 */
 async function updateData(songName: string, data: StateType) {
-  const infoRef = doc(db, 'test', songName);
+  const infoRef = doc(db, 'music', songName);
   await updateDoc(infoRef, { scores: arrayUnion(data.scores[0]) });
 
   /** instrument collection 에 추가 */

--- a/client/src/redux/FileSlice.tsx
+++ b/client/src/redux/FileSlice.tsx
@@ -1,0 +1,34 @@
+import { createSlice, Reducer, PayloadAction } from '@reduxjs/toolkit';
+
+// initalState 타입 정의
+
+interface PDF {
+  name: string;
+}
+
+interface StateType {
+  pdf: PDF;
+}
+
+// initalState 생성
+const initialState: StateType = { pdf: { name: '' } };
+
+// 슬라이스생성
+export const FileSlice = createSlice({
+  name: 'fileSlice',
+  initialState,
+  reducers: {
+    setFile: (state: StateType, action: PayloadAction<PDF>) => {
+      state.pdf = action.payload;
+      return state;
+    },
+  },
+});
+
+// 액션을 export 해준다.
+export const { setFile } = FileSlice.actions;
+
+// 슬라이스를 export 해준다.
+const FileReducer: Reducer<typeof initialState> = FileSlice.reducer;
+
+export default FileReducer;

--- a/client/src/redux/PostSlice.tsx
+++ b/client/src/redux/PostSlice.tsx
@@ -123,11 +123,15 @@ export const PostSlice = createSlice({
     setScoreId: (state: StateType, action: PayloadAction<string>) => {
       state.scores[0].scoreId = action.payload;
     },
+    initializeState: (state: StateType) => {
+      return (state = initialState);
+    },
   },
 });
 
 // 액션을 export 해준다.
 export const {
+  initializeState,
   setAlbumImg,
   setSongName,
   setArtist,

--- a/client/src/redux/PostSlice.tsx
+++ b/client/src/redux/PostSlice.tsx
@@ -33,6 +33,7 @@ export interface Score {
   songName: string;
   artist: string;
   albumImg: string;
+  downloadURL: string;
 }
 
 export interface StateType {
@@ -66,6 +67,7 @@ const initialState: StateType = {
       songName: '',
       artist: '',
       albumImg: '',
+      downloadURL: '',
     },
   ],
 };
@@ -123,6 +125,9 @@ export const PostSlice = createSlice({
     setScoreId: (state: StateType, action: PayloadAction<string>) => {
       state.scores[0].scoreId = action.payload;
     },
+    setDownloadURL: (state: StateType, action: PayloadAction<string>) => {
+      state.scores[0].downloadURL = action.payload;
+    },
     initializeState: (state: StateType) => {
       return (state = initialState);
     },
@@ -131,6 +136,7 @@ export const PostSlice = createSlice({
 
 // 액션을 export 해준다.
 export const {
+  setDownloadURL,
   initializeState,
   setAlbumImg,
   setSongName,

--- a/client/src/redux/PostSlice.tsx
+++ b/client/src/redux/PostSlice.tsx
@@ -40,6 +40,7 @@ export interface StateType {
   albumImg: string;
   songName: string;
   artist: string;
+  isDeleted: boolean;
   scores: Score[];
 }
 
@@ -49,6 +50,7 @@ const initialState: StateType = {
   albumImg: '',
   songName: '',
   artist: '',
+  isDeleted: false,
   scores: [
     {
       createdAt: new Date().toISOString(),

--- a/client/src/redux/store.ts
+++ b/client/src/redux/store.ts
@@ -10,7 +10,7 @@ import regReducer from './RegSlice';
 import userReducer from './UserSlice';
 import HeaderReducer from './HeaderSlice';
 import PostReducer from './PostSlice';
-
+import FileReducer from './FileSlice';
 const persistConfig = {
   // storage에 저장할 명칭
   key: 'user',
@@ -31,7 +31,8 @@ export const store = configureStore({
     userLoginInput: loginReducer,
     postHeader: HeaderReducer,
     defaultHeader: HeaderReducer,
-    PostInfo: PostReducer,
+    postInfo: PostReducer,
+    pdfFile: FileReducer,
   },
 
   middleware: (getDefaultMiddleware) =>


### PR DESCRIPTION
📌 헤더랑 로그인 상태에 따라서 /postmusic 경로가 /auth로도 이어지게 수정했습니다.

📌 Post 요청시 빈 필드가 있는지 확인하는 validation 을 만들었습니다.

📌 유저가 악보 작성시 업로드하는 pdf 형식의 악보를 firebase db에 저장하고 해당 다운로드 링크를 악보와 악기 db 테이블에 추가하였습니다

📌 유저가 악보 작성시 본인의 테이블을 만들어 악보정보를 저장하는 로직을 구현하고 있습니다..! 구현이 된다면 지금 데이터베이스 소프트리셋 진행 예정입니다! 