### PR TITLE
Feat: User 컬렉션에 데이터 추가 연동 구현

### DIFF
--- a/client/src/components/UI/molecules/PostInput/PostInput.tsx
+++ b/client/src/components/UI/molecules/PostInput/PostInput.tsx
@@ -14,11 +14,12 @@ import {
   setArtist,
   setSongName,
   setAlbumImg,
+  setScoreName,
 } from '../../../../redux/PostSlice';
 
 interface PostInputProps {
   text: string;
-  placeholder: string;
+  placeholder?: string;
   type: 'input' | 'dropdown';
 }
 
@@ -36,6 +37,9 @@ const PostInput = ({ type, text, placeholder }: PostInputProps) => {
   const [searchData, setSearchData] = useState([]);
   const [selectedData, setSelectedData] = useState<SelectedDataProps>();
 
+  if (text === '악보 제목') {
+    dispatch(setScoreName(userInput));
+  }
   useEffect(() => {
     if (userInput.length > 0) {
       // if (text === '곡 제목') dispatch(setSongName(userInput));

--- a/client/src/components/UI/molecules/PostSidebar/PostSidebar.tsx
+++ b/client/src/components/UI/molecules/PostSidebar/PostSidebar.tsx
@@ -27,7 +27,6 @@ const PostSidebar = () => {
       } else {
         alert('Only .pdf files are supported.');
       }
-
       dispatch(setFile(file));
     }
   };

--- a/client/src/components/UI/organisms/Header/Header.tsx
+++ b/client/src/components/UI/organisms/Header/Header.tsx
@@ -28,7 +28,11 @@ const Header = () => {
   };
 
   if (auth.currentUser) {
-    const user = [auth.currentUser.displayName, auth.currentUser.uid];
+    const user = [
+      auth.currentUser.displayName,
+      auth.currentUser.uid,
+      auth.currentUser.photoURL,
+    ];
     dispatch(setUserInfo(user));
   }
   const validateInputs = () => {
@@ -52,10 +56,12 @@ const Header = () => {
   const handleUpload = async () => {
     if (!validateInputs()) {
       toast.error('모든 필드를 입력해주세요.');
+    } else {
+      await getMusicData(data.songName, data).then(() => navigate('/'));
+      dispatch(setHeader(false));
+      dispatch(initializeState());
+      toast.success('악보 등록 성공!');
     }
-    await getMusicData(data.songName, data).then(() => navigate('/'));
-    dispatch(setHeader(false));
-    toast.success('악보 등록 성공!');
   };
 
   if (headerState) {

--- a/client/src/components/UI/organisms/Header/Header.tsx
+++ b/client/src/components/UI/organisms/Header/Header.tsx
@@ -20,7 +20,7 @@ const Header = () => {
   );
   const data = useSelector((state: RootState) => state.postInfo);
   const pdf = useSelector((state: RootState) => state.pdfFile);
-  console.log(data);
+
   const handleIsPost = () => {
     dispatch(setHeader(false));
     dispatch(initializeState());

--- a/client/src/components/UI/organisms/Header/Header.tsx
+++ b/client/src/components/UI/organisms/Header/Header.tsx
@@ -10,6 +10,7 @@ import { setHeader } from '../../../../redux/HeaderSlice';
 import { auth, getMusicData } from '../../../../firebase/firebase';
 import { setUserInfo, initializeState } from '../../../../redux/PostSlice';
 import { toast } from 'react-toastify';
+import React from 'react';
 
 const Header = () => {
   const cx = classNames.bind(styles);
@@ -105,4 +106,4 @@ const Header = () => {
     );
 };
 
-export default Header;
+export default React.memo(Header);

--- a/client/src/components/UI/organisms/MusicPostInfo/MusicPostInfo.tsx
+++ b/client/src/components/UI/organisms/MusicPostInfo/MusicPostInfo.tsx
@@ -21,12 +21,7 @@ const MusicPostInfo = ({ type }: MusicPostInfoProps) => {
           type="dropdown"
           placeholder="곡 제목을 입력해주세요"
         />
-        <PostInput
-          type="input"
-          text="곡 제목"
-          placeholder="예시) 사건의 지평선"
-        />
-        <PostInput type="input" text="원곡자" placeholder="예시) 윤하" />
+        <PostInput type="input" text="악보 제목" />
       </div>
     );
   } else if (type === '판매 상세 정보') {

--- a/client/src/redux/PostSlice.tsx
+++ b/client/src/redux/PostSlice.tsx
@@ -23,6 +23,7 @@ export interface Score {
   createdAt: string;
   author: userinfo;
   authorId: userinfo;
+  author_profile: userinfo;
   instType: instType;
   difficulty: difficulty;
   sheetType: sheetType;
@@ -57,6 +58,7 @@ const initialState: StateType = {
       createdAt: new Date().toISOString(),
       author: '',
       authorId: '',
+      author_profile: '',
       instType: '',
       difficulty: '',
       sheetType: '',
@@ -120,7 +122,8 @@ export const PostSlice = createSlice({
 
     setUserInfo: (state: StateType, action: PayloadAction<userinfo[]>) => {
       (state.scores[0].author = action.payload[0]),
-        (state.scores[0].authorId = action.payload[1]);
+        (state.scores[0].authorId = action.payload[1]),
+        (state.scores[0].author_profile = action.payload[2]);
     },
     setScoreId: (state: StateType, action: PayloadAction<string>) => {
       state.scores[0].scoreId = action.payload;

--- a/client/src/redux/PostSlice.tsx
+++ b/client/src/redux/PostSlice.tsx
@@ -30,6 +30,7 @@ export interface Score {
   price: string;
   youtubeURL?: string;
   detail: string;
+  scoreName: string;
   scoreId: string;
   songName: string;
   artist: string;
@@ -65,6 +66,7 @@ const initialState: StateType = {
       price: '',
       youtubeURL: '',
       detail: '',
+      scoreName: '',
       scoreId: '',
       songName: '',
       artist: '',
@@ -94,6 +96,9 @@ export const PostSlice = createSlice({
         scores: [{ ...state.scores[0], songName: action.payload }],
         songName: action.payload,
       };
+    },
+    setScoreName: (state: StateType, action: PayloadAction<string>) => {
+      state.scores[0].scoreName = action.payload;
     },
     setArtist: (state: StateType, action: PayloadAction<string>) => {
       return {
@@ -139,6 +144,7 @@ export const PostSlice = createSlice({
 
 // 액션을 export 해준다.
 export const {
+  setScoreName,
   setDownloadURL,
   initializeState,
   setAlbumImg,


### PR DESCRIPTION
📌 유저가 게시글을 올리면 해당 유저의 uid로 만들어진 Doc 이 user collection에 생성되며 해당 악보의 데이터가 들어갑니다
📌 구매한 이력은 구매 페이지가 완성이 될 때 진행해야 할 거 같습니다
📌 규식님 말씀하신대로 유저의 프로필 이미지 필드를 추가하였습니다 