### PR TITLE
Refactor: 상세페이지 탭메뉴 및 페이지네이션 수정

### DIFF
--- a/client/src/components/UI/molecules/Pagination/Pagination.tsx
+++ b/client/src/components/UI/molecules/Pagination/Pagination.tsx
@@ -35,17 +35,17 @@ const Pagination = ({
 
   useEffect(() => {
     const pageGroupArr = totalPageArr.slice(
-      currentPage - 1 - ((currentPage - 1) % 1),
-      currentPage - 1 - ((currentPage - 1) % 1) + 1
+      currentPage - 1 - ((currentPage - 1) % 5),
+      currentPage - 1 - ((currentPage - 1) % 5) + 5
     );
     setPageGroup([...pageGroupArr]);
-  }, [currentPage]);
+  }, [currentPage, totalLists]);
 
   const handlePrev = () => {
     if (!prevActive) return;
 
     // setIsPending(true);
-    setCurrentPage(pageGroup[0] - 1);
+    setCurrentPage(pageGroup[0] - 5);
   };
 
   const handlePage = (e: MouseEvent<HTMLButtonElement>) => {
@@ -58,7 +58,7 @@ const Pagination = ({
     if (!nextActive) return;
 
     // setIsPending(true);
-    setCurrentPage(pageGroup[0] + 1);
+    setCurrentPage(pageGroup[0] + 5);
   };
 
   return (

--- a/client/src/components/UI/molecules/Pagination/Pagination.tsx
+++ b/client/src/components/UI/molecules/Pagination/Pagination.tsx
@@ -21,7 +21,7 @@ const Pagination = ({
   setCurrentPage,
 }: PaginationProps) => {
   const cx = classNames.bind(styles);
-  const listPerpage = 1;
+  const listPerpage = 5;
   const totalPages = Math.ceil(totalLists / listPerpage);
   let totalPageArr = [1];
   if (totalPages > 1) {

--- a/client/src/components/UI/molecules/ScoreList/ScoreList.tsx
+++ b/client/src/components/UI/molecules/ScoreList/ScoreList.tsx
@@ -13,8 +13,16 @@ interface ScoreListProps {
 const ScoreList = ({ score, buttonEvent = 'edit' }: ScoreListProps) => {
   const cx = classNames.bind(styles);
   const { pathname } = useLocation();
-  const { artist, difficulty, instType, price, songName, author, scoreId } =
-    score;
+  const {
+    artist,
+    difficulty,
+    instType,
+    price,
+    songName,
+    author,
+    scoreId,
+    scoreName,
+  } = score;
 
   return (
     <div className={cx('wrapper')}>
@@ -22,7 +30,7 @@ const ScoreList = ({ score, buttonEvent = 'edit' }: ScoreListProps) => {
         <div className={cx('detail')}>
           <ul className={cx('score-song')}>
             <li>
-              <Text>{songName}</Text>
+              <Text>{scoreName}</Text>
             </li>
             <li>
               <Text color="gray">{artist}</Text>

--- a/client/src/components/UI/molecules/TabMenu/TabMenu.tsx
+++ b/client/src/components/UI/molecules/TabMenu/TabMenu.tsx
@@ -27,30 +27,18 @@ const TabMenu = ({
     <div className={cx('wrapper')}>
       <ul className={cx('tabs')}>
         {tabGroupArr.map((tab, idx) => (
-          <li
-            key={idx}
-            className={cx(
-              'tab',
-              `tab${idx + 1}`,
-              currentTab === idx && 'active'
-            )}
-          >
+          <li key={idx} className={cx('tab', currentTab === idx && 'active')}>
             <Button
               theme="transparent"
               size="auto"
               onClick={() => handleClick(tab, idx)}
             >
-              <Text
-                size="lg"
-                color={currentTab === idx ? 'black' : 'gray'}
-                weight={currentTab === idx ? 'medium' : 'regular'}
-              >
+              <Text size="lg" color="gray">
                 {tab}
               </Text>
             </Button>
           </li>
         ))}
-        <li className={cx('triangle')}></li>
       </ul>
     </div>
   );

--- a/client/src/components/UI/molecules/TabMenu/TabMenu.tsx
+++ b/client/src/components/UI/molecules/TabMenu/TabMenu.tsx
@@ -6,15 +6,21 @@ import { Dispatch, SetStateAction, useState } from 'react';
 interface TabMenuProps {
   tabGroupArr: string[];
   setClickedTab: Dispatch<SetStateAction<string>>;
+  setCurrentPage: Dispatch<SetStateAction<number>>;
 }
 
-const TabMenu = ({ tabGroupArr, setClickedTab }: TabMenuProps) => {
+const TabMenu = ({
+  tabGroupArr,
+  setClickedTab,
+  setCurrentPage,
+}: TabMenuProps) => {
   const cx = classNames.bind(styles);
   const [currentTab, setCurrentTab] = useState(0);
 
   const handleClick = (tab: string, idx: number) => {
     setCurrentTab(idx);
     setClickedTab(tab);
+    setCurrentPage(1);
   };
 
   return (

--- a/client/src/components/UI/molecules/TabMenu/TabMenu.tsx
+++ b/client/src/components/UI/molecules/TabMenu/TabMenu.tsx
@@ -4,21 +4,11 @@ import classNames from 'classnames/bind';
 import { Dispatch, SetStateAction, useState } from 'react';
 
 interface TabMenuProps {
-  tabGroupArr?: string[];
+  tabGroupArr: string[];
   setClickedTab: Dispatch<SetStateAction<string>>;
 }
 
-const TabMenu = ({
-  tabGroupArr = [
-    '전체',
-    '피아노',
-    '일렉 기타',
-    '어쿠스틱 기타',
-    '베이스',
-    '드럼',
-  ],
-  setClickedTab,
-}: TabMenuProps) => {
+const TabMenu = ({ tabGroupArr, setClickedTab }: TabMenuProps) => {
   const cx = classNames.bind(styles);
   const [currentTab, setCurrentTab] = useState(0);
 

--- a/client/src/components/UI/molecules/TabMenu/tabMenu.module.scss
+++ b/client/src/components/UI/molecules/TabMenu/tabMenu.module.scss
@@ -11,54 +11,47 @@
         max-width: #{1220/$font-size}rem;
         display: flex;
         align-items: start;
-        padding: .8rem 0 1rem;
+        padding: .8rem 0 .7rem;
         position: relative;
 
         .tab {
+            position: relative;
             margin: 0 1rem;
-            padding: 0 .5rem;
-        }
+            padding: 0 1rem;
 
-        .triangle {
-            position: absolute;
-            bottom: 0;
-            border-left: 1.5rem solid transparent;
-            border-top: 1.5rem solid transparent;
-            border-bottom: .9rem solid $white;
-            border-right: 1.5rem solid transparent;
-            opacity: 0;
-            transition: all 0.5s;
-        }
+            span:last-child {
+                &:hover {
+                    color: $light-green;
+                    transition: all .1s ease-in;
+                }
+            }
 
-        .tab1.active~.triangle {
-            left: 1.1rem;
-            opacity: 1;
-        }
+            &.active {
+                &::after {
+                    position: absolute;
+                    top: 1.9rem;
+                    left: 0;
+                    content: '';
+                    width: 100%;
+                    height: 4px;
+                    background-color: $light-green;
+                    animation: underline .5s;
+                }
 
-        .tab2.active~.triangle {
-            left: 6.6rem;
-            opacity: 1;
-        }
+                @keyframes underline {
+                    0% {
+                        width: 0;
+                    }
 
-        .tab3.active~.triangle {
-            left: 13.5rem;
-            opacity: 1;
-        }
+                    100% {
+                        width: 100%;
+                    }
+                }
 
-        .tab4.active~.triangle {
-            left: 22rem;
-            opacity: 1;
+                span:last-child {
+                    color: $black;
+                }
+            }
         }
-
-        .tab5.active~.triangle {
-            left: 30.4rem;
-            opacity: 1;
-        }
-
-        .tab6.active~.triangle {
-            left: 36.2rem;
-            opacity: 1;
-        }
-
     }
 }

--- a/client/src/components/UI/organisms/CategoryDetail/CategoryDetail.tsx
+++ b/client/src/components/UI/organisms/CategoryDetail/CategoryDetail.tsx
@@ -10,18 +10,17 @@ interface CategoryDetailProps {
   category: string;
   coverData: DocumentData;
   scoresByCategory: DocumentData;
-  totalLists: number;
 }
 
 const CategoryDetail = ({
   category,
   coverData,
   scoresByCategory,
-  totalLists,
 }: CategoryDetailProps) => {
   const cx = classNames.bind(styles);
   const { thumbnail, name, artist } = coverData;
   const [scores, setScores] = useState<DocumentData>([]);
+  const [totalLists, setTotalLists] = useState(0);
   const [currentPage, setCurrentPage] = useState(1);
   const [clickedTab, setClickedTab] = useState('전체');
   const [tabGroupArr, setTabGroupArr] = useState<string[]>([]);
@@ -29,11 +28,14 @@ const CategoryDetail = ({
   useEffect(() => {
     let currentData: DocumentData;
     if (clickedTab === '전체') {
+      setTotalLists(scoresByCategory?.length);
       currentData = scoresByCategory?.slice(currentPage - 1, currentPage + 0);
     } else {
-      currentData = scoresByCategory
-        ?.filter((el: DocumentData) => el.instType === clickedTab)
-        .slice(currentPage - 1, currentPage + 0);
+      const filteredData: DocumentData = scoresByCategory?.filter(
+        (el: DocumentData) => el.instType === clickedTab
+      );
+      setTotalLists(filteredData.length);
+      currentData = filteredData.slice(currentPage - 1, currentPage + 0);
     }
     setScores(currentData);
   }, [currentPage, scoresByCategory, clickedTab]);

--- a/client/src/components/UI/organisms/CategoryDetail/CategoryDetail.tsx
+++ b/client/src/components/UI/organisms/CategoryDetail/CategoryDetail.tsx
@@ -29,13 +29,19 @@ const CategoryDetail = ({
     let currentData: DocumentData;
     if (clickedTab === '전체') {
       setTotalLists(scoresByCategory?.length);
-      currentData = scoresByCategory?.slice(currentPage - 1, currentPage + 0);
+      currentData = scoresByCategory?.slice(
+        (currentPage - 1) * 5,
+        5 + (currentPage - 1) * 5
+      );
     } else {
       const filteredData: DocumentData = scoresByCategory?.filter(
         (el: DocumentData) => el.instType === clickedTab
       );
       setTotalLists(filteredData.length);
-      currentData = filteredData.slice(currentPage - 1, currentPage + 0);
+      currentData = filteredData.slice(
+        (currentPage - 1) * 5,
+        5 + (currentPage - 1) * 5
+      );
     }
     setScores(currentData);
   }, [currentPage, scoresByCategory, clickedTab]);

--- a/client/src/components/UI/organisms/CategoryDetail/CategoryDetail.tsx
+++ b/client/src/components/UI/organisms/CategoryDetail/CategoryDetail.tsx
@@ -24,6 +24,7 @@ const CategoryDetail = ({
   const [scores, setScores] = useState<DocumentData>([]);
   const [currentPage, setCurrentPage] = useState(1);
   const [clickedTab, setClickedTab] = useState('전체');
+  const [tabGroupArr, setTabGroupArr] = useState<string[]>([]);
 
   useEffect(() => {
     let currentData: DocumentData;
@@ -37,6 +38,13 @@ const CategoryDetail = ({
     setScores(currentData);
   }, [currentPage, scoresByCategory, clickedTab]);
 
+  useEffect(() => {
+    const tabGroup: string[] = Array.from(
+      new Set(scoresByCategory?.map((el: DocumentData) => el.instType))
+    );
+    setTabGroupArr(['전체', ...tabGroup]);
+  }, [scoresByCategory]);
+
   return (
     <>
       <div className={cx('cover-wrapper')}>
@@ -47,7 +55,9 @@ const CategoryDetail = ({
           artist={artist}
         />
       </div>
-      {category === '곡' && <TabMenu setClickedTab={setClickedTab} />}
+      {category === '곡' && (
+        <TabMenu setClickedTab={setClickedTab} tabGroupArr={tabGroupArr} />
+      )}
       <section className={cx('container')}>
         <h2>
           <Text size="xlg">악보</Text>

--- a/client/src/components/UI/organisms/CategoryDetail/CategoryDetail.tsx
+++ b/client/src/components/UI/organisms/CategoryDetail/CategoryDetail.tsx
@@ -56,7 +56,11 @@ const CategoryDetail = ({
         />
       </div>
       {category === '곡' && (
-        <TabMenu setClickedTab={setClickedTab} tabGroupArr={tabGroupArr} />
+        <TabMenu
+          setClickedTab={setClickedTab}
+          tabGroupArr={tabGroupArr}
+          setCurrentPage={setCurrentPage}
+        />
       )}
       <section className={cx('container')}>
         <h2>

--- a/client/src/components/pages/InstrumentDetail/InstrumentDetail.tsx
+++ b/client/src/components/pages/InstrumentDetail/InstrumentDetail.tsx
@@ -7,7 +7,6 @@ import { CategoryDetail } from '../../UI/organisms';
 const InstrumentDetail = () => {
   const [scoresByInst, setScoresByInst] = useState<DocumentData>([]);
   const [coverData, setCoverData] = useState<DocumentData>({});
-  const [totalLists, setTotalLists] = useState(0);
   const { instType } = useParams();
 
   useEffect(() => {
@@ -19,7 +18,6 @@ const InstrumentDetail = () => {
           artist: data.artist,
         });
         setScoresByInst(data.scores);
-        setTotalLists(data.scores.length);
       })
       .catch((error) => console.log(error));
   }, []);
@@ -29,7 +27,6 @@ const InstrumentDetail = () => {
       category="악기"
       coverData={coverData}
       scoresByCategory={scoresByInst}
-      totalLists={totalLists}
     />
   );
 };

--- a/client/src/components/pages/MusicDetail/MusicDetail.tsx
+++ b/client/src/components/pages/MusicDetail/MusicDetail.tsx
@@ -7,7 +7,6 @@ import { CategoryDetail } from '../../UI/organisms';
 const MusicDetail = () => {
   const [scoresByMusic, setScoresByMusic] = useState<DocumentData>([]);
   const [coverData, setCoverData] = useState<DocumentData>({});
-  const [totalLists, setTotalLists] = useState(0);
   const { songTitle } = useParams();
 
   useEffect(() => {
@@ -19,7 +18,6 @@ const MusicDetail = () => {
           artist: data.artist,
         });
         setScoresByMusic(data.scores);
-        setTotalLists(data.scores.length);
       })
       .catch((error) => console.log(error));
   }, []);
@@ -29,7 +27,6 @@ const MusicDetail = () => {
       category="곡"
       coverData={coverData}
       scoresByCategory={scoresByMusic}
-      totalLists={totalLists}
     />
   );
 };


### PR DESCRIPTION
상세페이지 탭메뉴
--
- 악보가 있는 악기 탭만 보여주도록 로직 추가했습니다.
- 탭을 동적으로 생성하다보니 기존의 active 애니메이션이 적합하지 않다고 판단되서 애니메이션을 변경했습니다.

페이지네이션
--
- 페이지당 리스트 5개씩, 페이지그룹을 5페이지 단위로 보여주도록 수정했습니다.
- 다른 탭 선택시 페이지를 1페이지로 초기화합니다.

