### PR TITLE
Feat: 메인페이지 무한스크롤 구현

### DIFF
--- a/client/src/components/UI/organisms/Carousel/Carousel.tsx
+++ b/client/src/components/UI/organisms/Carousel/Carousel.tsx
@@ -10,7 +10,7 @@ import 'swiper/scss/navigation';
 import './carousel.scss';
 
 // import required modules
-import { Pagination, Navigation } from 'swiper';
+import { Pagination, Navigation, Autoplay } from 'swiper';
 import { useNavigate } from 'react-router-dom';
 
 export default function Carousel() {
@@ -25,8 +25,12 @@ export default function Carousel() {
         pagination={{
           clickable: true,
         }}
+        autoplay={{
+          delay: 4000,
+          disableOnInteraction: false,
+        }}
         navigation={true}
-        modules={[Pagination, Navigation]}
+        modules={[Pagination, Navigation, Autoplay]}
         className="mySwiper"
       >
         <SwiperSlide>

--- a/client/src/components/UI/organisms/ScoreInfoMain/ScoreInfoMain.tsx
+++ b/client/src/components/UI/organisms/ScoreInfoMain/ScoreInfoMain.tsx
@@ -64,12 +64,15 @@ function ScoreInfoMain({
         page={page}
         scoreType={scoreType}
       />
-      <YouTube
-        videoId={formattedURL}
-        opts={opts}
-        onReady={onPlayerReady}
-        onEnd={onPlayerEnd}
-      />
+      {youtubeURL && (
+        <YouTube
+          videoId={formattedURL}
+          opts={opts}
+          onReady={onPlayerReady}
+          onEnd={onPlayerEnd}
+        />
+      )}
+
       <ScoreInfoExplain scoreExplain={scoreExplain} />
     </div>
   );

--- a/client/src/components/UI/organisms/ScoreInfoMain/scoreInfoMain.module.scss
+++ b/client/src/components/UI/organisms/ScoreInfoMain/scoreInfoMain.module.scss
@@ -1,5 +1,5 @@
 @import '/src/utils/utils';
 
 .scoreinfo-main > div {
-  margin-top: 1rem;
+  margin-top: 2.5rem;
 }

--- a/client/src/components/pages/Main/Main.tsx
+++ b/client/src/components/pages/Main/Main.tsx
@@ -1,7 +1,18 @@
-import { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback, useRef } from 'react';
 import { MainGrid } from '../../UI/organisms';
 import { Carousel } from '../../UI/organisms';
 import { getMusics } from '../../../firebase/firebase';
+import { initializeApp } from 'firebase/app';
+import {
+  getFirestore,
+  collection,
+  getDocs,
+  limit,
+  orderBy,
+  query,
+  startAfter,
+  DocumentData,
+} from 'firebase/firestore/lite';
 
 export type MusicData = {
   artist: string;
@@ -34,16 +45,99 @@ function Main() {
   const [musicArr, setMusicArr] = useState<MusicData>([
     { artist: '', scores: [], albumImg: '', songName: '', songId: null },
   ]);
-  console.log(musicArr);
-  useEffect(() => {
-    getMusics().then((data) => {
-      setMusicArr(data);
-    });
+  const [key, setKey] = useState<DocumentData>(); // 마지막으로 불러온 스냅샷 상태
+  const [noMore, setNoMore] = useState(false); // 추가로 요청할 데이터 없다는 flag
+  const target = useRef() as React.MutableRefObject<HTMLDivElement>;
+
+  const firebaseConfig = {
+    apiKey: 'AIzaSyAZ4hRKbN3-Hq3w2v07pS-4KBikVP-4Wi0',
+    authDomain: 'garden-of-musicsheet.firebaseapp.com',
+    projectId: 'garden-of-musicsheet',
+    storageBucket: 'garden-of-musicsheet.appspot.com',
+    messagingSenderId: '19630033251',
+    appId: '1:19630033251:web:b2170fb7c5224edff36b56',
+  };
+
+  const app = initializeApp(firebaseConfig);
+  const db = getFirestore(app);
+
+  const getFirstPage = useCallback(async () => {
+    const queryRef = query(
+      collection(db, 'music'),
+      orderBy('songId'), // 최신 작성순으로 정렬
+      limit(8)
+    );
+    try {
+      const snap = await getDocs(queryRef);
+      const docsArray = snap.docs.map((doc: DocumentData) => doc.data());
+      // 문서 저장
+      setMusicArr(docsArray);
+      // 커서로 사용할 마지막 문서 스냅샷 저장
+      setKey(snap.docs[snap.docs.length - 1]);
+      console.log(key);
+    } catch (err) {
+      console.log(err);
+    }
   }, []);
+
+  // 추가 요청 함수
+  const loadMore = useCallback(async () => {
+    const queryRef = query(
+      collection(db, 'music'),
+      orderBy('songId'),
+      startAfter(key), // 마지막 커서 기준으로 추가 요청을 보내도록 쿼리 전송
+      limit(6)
+    );
+    try {
+      const snap = await getDocs(queryRef);
+      console.log(snap.empty);
+      snap.empty
+        ? setNoMore(true) // 만약 스냅샷이 존재 하지 않는다면 더이상 불러올수 없다는 flag 설정
+        : setKey(snap.docs[snap.docs.length - 1]); // 존재한다면 처음과 마찬가지고 마지막 커서 저장
+      const docsArray = snap.docs.map((doc: DocumentData) => doc.data());
+      setMusicArr([...musicArr, ...docsArray]); // 기존 데이터와 합쳐서 상태 저장
+    } catch (err) {
+      console.log(err);
+    }
+  }, [musicArr, key]);
+
+  // 지정된 요소가 화면에 보일때 실행할 콜백함수
+  const onIntersect: IntersectionObserverCallback = useCallback(
+    async ([entry], observer) => {
+      // 만약에 지정한 요소가 화면에 보이거나 현재 데이터를 더 불러오는 상황이 아닐경우,
+      // 기존 요소의 주시를 해체하고 추가로 3개의 문서를 더 불러오도록 설정
+      if (entry.isIntersecting) {
+        observer.unobserve(entry.target);
+        await loadMore();
+      }
+    },
+    [loadMore]
+  );
+
+  useEffect(() => {
+    getFirstPage();
+  }, [getFirstPage]);
+
+  // target 요소의 ref가 전달되었을때 해당 요소를 주시할수 있도록 observer 인스턴스 생성후 전달
+  useEffect(() => {
+    let observer: IntersectionObserver;
+    if (target && !noMore) {
+      observer = new IntersectionObserver(onIntersect, {
+        threshold: 0,
+      });
+      observer.observe(target.current);
+    }
+    // 메모리 해제 작업
+    return () => {
+      observer && observer.disconnect();
+    };
+  }, [target, onIntersect, noMore]);
+
   return (
     <>
       <Carousel />
       <MainGrid musicData={musicArr} />
+      <div ref={target}></div>
     </>
   );
 }

--- a/client/src/components/pages/Main/main.module.scss
+++ b/client/src/components/pages/Main/main.module.scss
@@ -1,0 +1,6 @@
+@import '/src/utils/utils';
+
+.target {
+  height: 1rem;
+  width: 100%;
+}

--- a/client/src/components/pages/ScoreInfo/scoreInfo.module.scss
+++ b/client/src/components/pages/ScoreInfo/scoreInfo.module.scss
@@ -2,7 +2,7 @@
 
 .scoreinfo {
   display: grid;
-  grid-template-columns: 1fr 4fr 1fr;
+  grid-template-columns: 1fr auto 1fr;
   grid-template-rows: auto;
   position: relative;
 
@@ -19,7 +19,8 @@
     position: sticky;
     top: 10%;
     height: #{330 / $font-size}rem;
-    margin: 0 1rem;
+    margin-left: 2.5rem;
+    margin-right: 1rem;
   }
   > aside:nth-child(3) {
     grid-column: 1 / 2;


### PR DESCRIPTION
메인스크롤 무한스크롤 구현했습니다.
처음 메인페이지 렌더링시 8개의 노래 데이터를 가져오고 그 이후부터는 스크롤 할 때마다 6개씩 불러옵니다.
곡 정렬은 songId로 이루어집니다.
아직 key값은 songId 그대로 두었습니다.
이후 key중복 문제가 또 발생하면 uuid로 바꾸겠습니다.

승민님이 말씀해주신 상세페이지 css 수정사항도 반영하였습니다.

메인페이지 케러셀도 4초마다 다음페이지로 자동으로 이동하게 설정하였습니다.