### PR TITLE
Refactor: 메인페이지에서 마지막 데이터일 경우에 Footer가 보이도록 수정

### DIFF
--- a/client/src/components/pages/Layout/Layout.tsx
+++ b/client/src/components/pages/Layout/Layout.tsx
@@ -1,17 +1,34 @@
 import './layout.module.scss';
-import { Outlet } from 'react-router-dom';
+import { Outlet, useLocation } from 'react-router-dom';
 import { Footer, Header } from '../../UI/organisms';
+import { useSelector } from 'react-redux';
+import { RootState } from '../../../redux/store';
 
 const Layout = () => {
-  return (
-    <>
-      <Header />
-      <main>
-        <Outlet />
-      </main>
-      <Footer />
-    </>
-  );
+  const { pathname } = useLocation();
+  const showFooter = useSelector((state: RootState) => state.showFooter);
+
+  if (pathname === '/') {
+    return (
+      <>
+        <Header />
+        <main>
+          <Outlet />
+        </main>
+        {showFooter && <Footer />}
+      </>
+    );
+  } else {
+    return (
+      <>
+        <Header />
+        <main>
+          <Outlet />
+        </main>
+        <Footer />
+      </>
+    );
+  }
 };
 
 export default Layout;

--- a/client/src/components/pages/Main/Main.tsx
+++ b/client/src/components/pages/Main/Main.tsx
@@ -15,6 +15,8 @@ import {
 
 import classNames from 'classnames/bind';
 import styles from './main.module.scss';
+import { useDispatch } from 'react-redux';
+import { showFooter } from '../../../redux/FooterSlice';
 
 export type MusicData = {
   artist: string;
@@ -52,6 +54,11 @@ function Main() {
   const [key, setKey] = useState<DocumentData>(); // 마지막으로 불러온 스냅샷 상태
   const [noMore, setNoMore] = useState(false); // 추가로 요청할 데이터 없다는 flag
   const target = useRef() as React.MutableRefObject<HTMLDivElement>;
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(showFooter(noMore));
+  }, [noMore]);
 
   const firebaseConfig = {
     apiKey: 'AIzaSyAZ4hRKbN3-Hq3w2v07pS-4KBikVP-4Wi0',

--- a/client/src/redux/FooterSlice.tsx
+++ b/client/src/redux/FooterSlice.tsx
@@ -1,0 +1,17 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+export const footerSlice = createSlice({
+  name: 'footerSlice',
+  initialState: false,
+  reducers: {
+    showFooter: (state: boolean, action: PayloadAction<boolean>) => {
+      state = action.payload;
+      return state;
+    },
+  },
+});
+
+export const { showFooter } = footerSlice.actions;
+
+const footerReducer = footerSlice.reducer;
+export default footerReducer;

--- a/client/src/redux/store.ts
+++ b/client/src/redux/store.ts
@@ -10,6 +10,8 @@ import regReducer from './RegSlice';
 import userReducer from './UserSlice';
 import PostReducer from './PostSlice';
 import FileReducer from './FileSlice';
+import FooterReducer from './FooterSlice';
+
 const persistConfig = {
   // storage에 저장할 명칭
   key: 'user',
@@ -30,6 +32,7 @@ export const store = configureStore({
     userLoginInput: loginReducer,
     postInfo: PostReducer,
     pdfFile: FileReducer,
+    showFooter: FooterReducer,
   },
 
   middleware: (getDefaultMiddleware) =>


### PR DESCRIPTION
문제
--
메인페이지에서 스크롤이 하단에 닿을때마다 Footer가 반짝 보임

해결
--
- 메인페이지의 더이상 불러올 데이터가 없음을 나타내는 noMore 상태를 이용해서 해결했습니다!
- Footer의 전역 상태를 만들고 noMore 상태와 동일한 상태를 갖도록 해주었고, noMore 상태가 true일 때 Footer를 표시하도록 했습니다.
- 하지만 이렇게만 하면 다른 페이지에서 Footer가 표시되지 않는 문제가 있어서, pathname을 기준으로 레이아웃 분기를 해주었습니다.