### PR TITLE
Feat: 게시글 삭제 구현

### DIFF
--- a/client/src/components/UI/molecules/CategoryCover/categoryCover.module.scss
+++ b/client/src/components/UI/molecules/CategoryCover/categoryCover.module.scss
@@ -36,12 +36,16 @@
       .bottom {
         display: flex;
         justify-content: space-between;
+        @media screen and (max-width: 500px) {
+          flex-direction: column;
+        }
         .cash {
           display: flex;
           align-items: center;
         }
         .edit {
           display: flex;
+          align-items: center;
         }
       }
     }

--- a/client/src/components/UI/molecules/MyPageModal/MyPageModal.tsx
+++ b/client/src/components/UI/molecules/MyPageModal/MyPageModal.tsx
@@ -2,16 +2,17 @@ import styles from './myPageModal.module.scss';
 import classNames from 'classnames/bind';
 import { Button, ImgLayout, Text } from '../../atoms';
 import { Dispatch, SetStateAction, useRef, useState } from 'react';
-import { auth, userOptout } from '../../../../firebase/firebase';
-import { toast } from 'react-toastify';
-import { useNavigate } from 'react-router-dom';
-import { deleteUser, updateCurrentUser, updateProfile } from 'firebase/auth';
-import { ThreeDots } from 'react-loader-spinner';
-import { persistor } from '../../../../redux/store';
 import {
+  auth,
+  userOptout,
   postProfilePicture,
   updateUserPicture,
 } from '../../../../firebase/firebase';
+import { toast } from 'react-toastify';
+import { useNavigate } from 'react-router-dom';
+import { updateProfile } from 'firebase/auth';
+import { ThreeDots } from 'react-loader-spinner';
+import { persistor } from '../../../../redux/store';
 import { useDispatch } from 'react-redux';
 import { setFile } from '../../../../redux/FileSlice';
 import { setUserProfilePicture } from '../../../../redux/UserSlice';

--- a/client/src/components/UI/molecules/ScoreInfoHeader/ScoreInfoHeader.tsx
+++ b/client/src/components/UI/molecules/ScoreInfoHeader/ScoreInfoHeader.tsx
@@ -24,7 +24,7 @@ function ScoreInfoHeader({ scoreName, singer, date }: ScoreInfoHeaderProps) {
       const scoreId = params.scoreId.toString();
       deleteArticle(user.uid, scoreId);
     }
-    toast.success('삭제됐습니다!');
+    toast.success('삭제했습니다!');
     navigate('/');
   };
 

--- a/client/src/components/UI/molecules/ScoreInfoHeader/ScoreInfoHeader.tsx
+++ b/client/src/components/UI/molecules/ScoreInfoHeader/ScoreInfoHeader.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
 import { Text, Button } from '../../atoms';
 import styles from './scoreinfoheader.module.scss';
 import classNames from 'classnames/bind';
 import { useLocation, useNavigate } from 'react-router-dom';
-
+import { deleteArticle, auth } from '../../../../firebase/firebase';
+import { toast } from 'react-toastify';
 interface ScoreInfoHeaderProps {
   scoreName: string;
   singer: string;
@@ -15,6 +15,15 @@ function ScoreInfoHeader({ scoreName, singer, date }: ScoreInfoHeaderProps) {
   const navigate = useNavigate();
   const { pathname } = useLocation();
   const formattedDate = new Intl.DateTimeFormat('ko-kr').format(new Date(date));
+
+  const handleDeleteArticle = async () => {
+    const user = auth.currentUser;
+    if (user) {
+      deleteArticle(user.uid);
+    }
+    toast.success('삭제됐습니다!');
+    navigate('/');
+  };
 
   return (
     <div className={cx('songinfo-header')}>
@@ -35,7 +44,11 @@ function ScoreInfoHeader({ scoreName, singer, date }: ScoreInfoHeaderProps) {
         >
           <Text color="gray">수정</Text>
         </Button>
-        <Button theme="transparent" size="auto">
+        <Button
+          theme="transparent"
+          size="auto"
+          onClick={() => handleDeleteArticle()}
+        >
           <Text color="gray">삭제</Text>
         </Button>
       </div>

--- a/client/src/components/UI/molecules/ScoreInfoHeader/ScoreInfoHeader.tsx
+++ b/client/src/components/UI/molecules/ScoreInfoHeader/ScoreInfoHeader.tsx
@@ -24,8 +24,8 @@ function ScoreInfoHeader({ scoreName, singer, date }: ScoreInfoHeaderProps) {
       const scoreId = params.scoreId.toString();
       deleteArticle(user.uid, scoreId);
     }
-    // toast.success('삭제됐습니다!');
-    // navigate('/');
+    toast.success('삭제됐습니다!');
+    navigate('/');
   };
 
   return (

--- a/client/src/components/UI/molecules/ScoreInfoHeader/ScoreInfoHeader.tsx
+++ b/client/src/components/UI/molecules/ScoreInfoHeader/ScoreInfoHeader.tsx
@@ -2,8 +2,9 @@ import { Text, Button } from '../../atoms';
 import styles from './scoreinfoheader.module.scss';
 import classNames from 'classnames/bind';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { deleteArticle, auth } from '../../../../firebase/firebase';
+import { auth, deleteArticle } from '../../../../firebase/firebase';
 import { toast } from 'react-toastify';
+import { useParams } from 'react-router-dom';
 interface ScoreInfoHeaderProps {
   scoreName: string;
   singer: string;
@@ -13,16 +14,18 @@ interface ScoreInfoHeaderProps {
 function ScoreInfoHeader({ scoreName, singer, date }: ScoreInfoHeaderProps) {
   const cx = classNames.bind(styles);
   const navigate = useNavigate();
+  const params = useParams();
   const { pathname } = useLocation();
   const formattedDate = new Intl.DateTimeFormat('ko-kr').format(new Date(date));
 
   const handleDeleteArticle = async () => {
     const user = auth.currentUser;
-    if (user) {
-      deleteArticle(user.uid);
+    if (user && params.scoreId) {
+      const scoreId = params.scoreId.toString();
+      deleteArticle(user.uid, scoreId);
     }
-    toast.success('삭제됐습니다!');
-    navigate('/');
+    // toast.success('삭제됐습니다!');
+    // navigate('/');
   };
 
   return (

--- a/client/src/components/UI/molecules/UserDropdown/UserMenu/UserMenu.tsx
+++ b/client/src/components/UI/molecules/UserDropdown/UserMenu/UserMenu.tsx
@@ -1,7 +1,6 @@
 import styles from './userMenu.module.scss';
 import classNames from 'classnames/bind';
 import { Button, Icon, Text } from '../../../atoms';
-import { useDispatch } from 'react-redux';
 import { auth } from '../../../../../firebase/firebase';
 import { useNavigate } from 'react-router-dom';
 import { persistor } from '../../../../../redux/store';
@@ -13,7 +12,6 @@ interface UserMenuProps {
 
 const UserMenu = ({ setDropdown }: UserMenuProps) => {
   const cx = classNames.bind(styles);
-  const dispatch = useDispatch();
   const navigate = useNavigate();
 
   const handleSignOut = async () => {

--- a/client/src/components/UI/organisms/CategoryDetail/CategoryDetail.tsx
+++ b/client/src/components/UI/organisms/CategoryDetail/CategoryDetail.tsx
@@ -5,6 +5,7 @@ import { Text } from '../../atoms';
 import { useEffect, useState } from 'react';
 import { DocumentData } from 'firebase/firestore/lite';
 import { v4 as uuid } from 'uuid';
+import { ScoreInfoType } from '../../../pages/Main/Main';
 
 interface CategoryDetailProps {
   category: string;
@@ -26,6 +27,9 @@ const CategoryDetail = ({
   const [tabGroupArr, setTabGroupArr] = useState<string[]>([]);
 
   useEffect(() => {
+    scoresByCategory = scoresByCategory
+      .filter((el: ScoreInfoType) => !el.isDeleted)
+      .filter((el: ScoreInfoType) => !el.isOptout);
     let currentData: DocumentData;
     if (clickedTab === '전체') {
       setTotalLists(scoresByCategory?.length);

--- a/client/src/components/UI/organisms/MainGrid/MainGrid.tsx
+++ b/client/src/components/UI/organisms/MainGrid/MainGrid.tsx
@@ -7,6 +7,26 @@ import { MusicData } from '../../../pages/Main/Main';
 function MainGrid({ musicData }: { musicData: MusicData }) {
   const cx = classNames.bind(styles);
 
+  console.log(musicData);
+
+  const HandleDeletedData = () => {
+    const validData = musicData.filter((data) => !data.isDeleted);
+
+    return (
+      <>
+        {validData.map((data) => (
+          <MainSongSection
+            key={data.songId}
+            songTitle={data.songName}
+            singer={data.artist}
+            albumImg={data.albumImg}
+            scores={data.scores}
+          />
+        ))}
+      </>
+    );
+  };
+
   return (
     <div className={cx('main-content-wrapper')}>
       <div className={cx('main-content-grid')}>
@@ -15,18 +35,7 @@ function MainGrid({ musicData }: { musicData: MusicData }) {
             곡
           </Text>
         </h1>
-        {musicData &&
-          musicData.map((el) => {
-            return (
-              <MainSongSection
-                key={el.songId}
-                songTitle={el.songName}
-                singer={el.artist}
-                albumImg={el.albumImg}
-                scores={el.scores}
-              />
-            );
-          })}
+        <HandleDeletedData />
       </div>
     </div>
   );

--- a/client/src/components/UI/organisms/MainGrid/MainGrid.tsx
+++ b/client/src/components/UI/organisms/MainGrid/MainGrid.tsx
@@ -7,8 +7,6 @@ import { MusicData } from '../../../pages/Main/Main';
 function MainGrid({ musicData }: { musicData: MusicData }) {
   const cx = classNames.bind(styles);
 
-  console.log(musicData);
-
   const HandleDeletedData = () => {
     const validData = musicData.filter((data) => !data.isDeleted);
 

--- a/client/src/components/UI/organisms/MainGrid/MainGrid.tsx
+++ b/client/src/components/UI/organisms/MainGrid/MainGrid.tsx
@@ -8,7 +8,7 @@ function MainGrid({ musicData }: { musicData: MusicData }) {
   const cx = classNames.bind(styles);
 
   const HandleDeletedData = () => {
-    const validData = musicData.filter((data) => !data.isDeleted);
+    const validData = (musicData ?? []).filter((data) => !data.isDeleted);
 
     return (
       <>

--- a/client/src/components/UI/organisms/MainGrid/MainGrid.tsx
+++ b/client/src/components/UI/organisms/MainGrid/MainGrid.tsx
@@ -3,6 +3,7 @@ import { Text } from '../../atoms';
 import styles from './maingrid.module.scss';
 import classNames from 'classnames/bind';
 import { MusicData } from '../../../pages/Main/Main';
+import { v4 as uuidv4 } from 'uuid';
 
 function MainGrid({ musicData }: { musicData: MusicData }) {
   const cx = classNames.bind(styles);
@@ -14,7 +15,7 @@ function MainGrid({ musicData }: { musicData: MusicData }) {
       <>
         {validData.map((data) => (
           <MainSongSection
-            key={data.songId}
+            key={uuidv4()}
             songTitle={data.songName}
             singer={data.artist}
             albumImg={data.albumImg}

--- a/client/src/components/UI/organisms/MainSongSection/MainSongSection.tsx
+++ b/client/src/components/UI/organisms/MainSongSection/MainSongSection.tsx
@@ -29,7 +29,7 @@ function MainSongSection({
 // price,
 MainSongSectionProps) {
   const cx = classNames.bind(styles);
-
+  scores = scores.slice(-3);
   return (
     <section className={cx('container')}>
       <SongTitle songTitle={songTitle} singer={singer} albumImg={albumImg} />

--- a/client/src/components/UI/organisms/MainSongSection/MainSongSection.tsx
+++ b/client/src/components/UI/organisms/MainSongSection/MainSongSection.tsx
@@ -29,7 +29,7 @@ function MainSongSection({
 // price,
 MainSongSectionProps) {
   const cx = classNames.bind(styles);
-  scores = scores.slice(-3);
+  if (scores) scores = scores.slice(-3);
   return (
     <section className={cx('container')}>
       <SongTitle songTitle={songTitle} singer={singer} albumImg={albumImg} />

--- a/client/src/components/UI/organisms/MainSongSection/MainSongSection.tsx
+++ b/client/src/components/UI/organisms/MainSongSection/MainSongSection.tsx
@@ -36,7 +36,7 @@ MainSongSectionProps) {
       <div className={cx('scorelist-wrapper')}>
         {scores &&
           scores.map((el, idx) => {
-            if (idx < 3) {
+            if (idx < 3 && el.isDeleted === false) {
               return (
                 <MainScoreList
                   key={el.scoreId}

--- a/client/src/components/UI/organisms/MainSongSection/MainSongSection.tsx
+++ b/client/src/components/UI/organisms/MainSongSection/MainSongSection.tsx
@@ -36,7 +36,7 @@ MainSongSectionProps) {
       <div className={cx('scorelist-wrapper')}>
         {scores &&
           scores.map((el, idx) => {
-            if (idx < 3 && el.isDeleted === false) {
+            if (idx < 3 && el.isDeleted === false && el.isOptout === false) {
               return (
                 <MainScoreList
                   key={el.scoreId}

--- a/client/src/components/UI/organisms/MyPageTop/MyPageTop.tsx
+++ b/client/src/components/UI/organisms/MyPageTop/MyPageTop.tsx
@@ -1,7 +1,7 @@
 import styles from './myPageTop.module.scss';
 import classNames from 'classnames/bind';
 import { CategoryCover } from '../../molecules';
-import { Dispatch, SetStateAction, useState } from 'react';
+import { Dispatch, SetStateAction } from 'react';
 
 interface MyPageTopProps {
   username: string; // userName

--- a/client/src/components/UI/organisms/UserAuth/UserAuth.tsx
+++ b/client/src/components/UI/organisms/UserAuth/UserAuth.tsx
@@ -55,7 +55,12 @@ const UserAuth = ({ type }: UserAuthProps) => {
           userRegData.email,
           userRegData.password,
           userRegData.nickname
-        );
+        ).then((response) => {
+          if (typeof response !== 'undefined') {
+            const { displayName, email, phoneNumber, photoURL } = response;
+            dispatch(userInfo({ displayName, email, phoneNumber, photoURL }));
+          }
+        });
         localStorage.getItem('authorization') ? navigate('/') : null;
       } catch (err) {
         console.log(err);

--- a/client/src/components/pages/Instrument/Instrument.tsx
+++ b/client/src/components/pages/Instrument/Instrument.tsx
@@ -2,11 +2,9 @@ import classNames from 'classnames/bind';
 import { Text } from '../../UI/atoms';
 import { InstrumentLists } from '../../UI/organisms';
 import styles from './instrument.module.scss';
-import { useDispatch } from 'react-redux';
 
 const Instrument = () => {
   const cx = classNames.bind(styles);
-  const dispatch = useDispatch();
 
   return (
     <section className={cx('container')}>

--- a/client/src/components/pages/InstrumentDetail/InstrumentDetail.tsx
+++ b/client/src/components/pages/InstrumentDetail/InstrumentDetail.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { getScoresByCategory } from '../../../firebase/firebase';
 import { CategoryDetail } from '../../UI/organisms';
-
+import { Score } from '../../../redux/PostSlice';
 const InstrumentDetail = () => {
   const [scoresByInst, setScoresByInst] = useState<DocumentData>([]);
   const [coverData, setCoverData] = useState<DocumentData>({});
@@ -17,7 +17,11 @@ const InstrumentDetail = () => {
           thumbnail: data.thumbnail || data.albumImg,
           artist: data.artist,
         });
-        setScoresByInst(data.scores);
+        // 삭제된, 회원탈퇴한 유저의 데이터 필터
+        const filteredData = data.scores
+          .filter((data: Score) => !data.isDeleted)
+          .filter((data: Score) => !data.isOptout);
+        setScoresByInst(filteredData);
       })
       .catch((error) => console.log(error));
   }, []);

--- a/client/src/components/pages/Main/Main.tsx
+++ b/client/src/components/pages/Main/Main.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState, useCallback, useRef } from 'react';
-import { MainGrid } from '../../UI/organisms';
-import { Carousel } from '../../UI/organisms';
+import { MainGrid, Carousel } from '../../UI/organisms';
 import { DocumentData } from 'firebase/firestore/lite';
 import classNames from 'classnames/bind';
 import styles from './main.module.scss';

--- a/client/src/components/pages/Main/Main.tsx
+++ b/client/src/components/pages/Main/Main.tsx
@@ -25,6 +25,7 @@ export type MusicData = {
   albumImg: string;
   songName: string;
   songId: number | null;
+  isDeleted: boolean;
 }[];
 
 export interface ScoreInfoType {

--- a/client/src/components/pages/Main/Main.tsx
+++ b/client/src/components/pages/Main/Main.tsx
@@ -1,23 +1,13 @@
 import React, { useEffect, useState, useCallback, useRef } from 'react';
 import { MainGrid } from '../../UI/organisms';
 import { Carousel } from '../../UI/organisms';
-import { initializeApp } from 'firebase/app';
-import {
-  getFirestore,
-  collection,
-  getDocs,
-  limit,
-  orderBy,
-  query,
-  startAfter,
-  DocumentData,
-} from 'firebase/firestore/lite';
-
+import { DocumentData } from 'firebase/firestore/lite';
 import classNames from 'classnames/bind';
 import styles from './main.module.scss';
 import { useDispatch } from 'react-redux';
 import { showFooter } from '../../../redux/FooterSlice';
 import Spinner from '../../../utils/Spinner/Spinner';
+import { getMainPageData, getMoreMainData } from '../../../firebase/firebase';
 
 export type MusicData = {
   artist: string;
@@ -57,65 +47,27 @@ function Main() {
   const [noMore, setNoMore] = useState(false); // 추가로 요청할 데이터 없다는 flag
   const target = useRef() as React.MutableRefObject<HTMLDivElement>;
   const dispatch = useDispatch();
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     dispatch(showFooter(noMore));
   }, [noMore]);
 
-  const firebaseConfig = {
-    apiKey: 'AIzaSyAZ4hRKbN3-Hq3w2v07pS-4KBikVP-4Wi0',
-    authDomain: 'garden-of-musicsheet.firebaseapp.com',
-    projectId: 'garden-of-musicsheet',
-    storageBucket: 'garden-of-musicsheet.appspot.com',
-    messagingSenderId: '19630033251',
-    appId: '1:19630033251:web:b2170fb7c5224edff36b56',
-  };
-
-  const app = initializeApp(firebaseConfig);
-  const db = getFirestore(app);
-
-  const getFirstPage = useCallback(async () => {
-    const queryRef = query(
-      collection(db, 'music'),
-      orderBy('songId'), // 최신 작성순으로 정렬
-      limit(8)
-    );
-    try {
-      const snap = await getDocs(queryRef);
-      const docsArray = snap.docs.map((doc: DocumentData) => doc.data());
-      // 문서 저장
-      setMusicArr(docsArray);
-      setLoading(!loading);
-      // 커서로 사용할 마지막 문서 스냅샷 저장
-      setKey(snap.docs[snap.docs.length - 1]);
-    } catch (err) {
-      console.log(err);
-    }
+  useEffect(() => {
+    getMainPageData().then((data) => {
+      data && setMusicArr(data.docsArray);
+      data && setKey(data.key);
+    });
+    setLoading(false);
   }, []);
-  // 추가 요청 함수
+
   const loadMore = useCallback(async () => {
-    let queryRef;
-    if (key !== undefined) {
-      queryRef = query(
-        collection(db, 'music'),
-        orderBy('songId'),
-        startAfter(key), // 마지막 커서 기준으로 추가 요청을 보내도록 쿼리 전송
-        limit(6)
-      );
-    }
-    try {
-      let snap;
-      if (queryRef !== undefined) {
-        snap = await getDocs(queryRef);
-        snap.empty
-          ? setNoMore(true) // 만약 스냅샷이 존재 하지 않는다면 더이상 불러올수 없다는 flag 설정
-          : setKey(snap.docs[snap.docs.length - 1]); // 존재한다면 처음과 마찬가지고 마지막 커서 저장
-        const docsArray = snap.docs.map((doc: DocumentData) => doc.data());
-        setMusicArr([...musicArr, ...docsArray]); // 기존 데이터와 합쳐서 상태 저장
-      }
-    } catch (err) {
-      console.log(err);
+    if (key) {
+      await getMoreMainData(key).then((data) => {
+        data && setMusicArr([...musicArr, ...data.docsArray]);
+        data && setNoMore(data.noMore);
+        data?.key && setKey(data.key);
+      });
     }
   }, [musicArr, key]);
 
@@ -131,10 +83,6 @@ function Main() {
     },
     [loadMore]
   );
-
-  useEffect(() => {
-    getFirstPage();
-  }, [getFirstPage]);
 
   // target 요소의 ref가 전달되었을때 해당 요소를 주시할수 있도록 observer 인스턴스 생성후 전달
   useEffect(() => {
@@ -154,7 +102,7 @@ function Main() {
   return (
     <>
       <Carousel />
-      {loading ? (
+      {!loading ? (
         <>
           <MainGrid musicData={musicArr} />
         </>

--- a/client/src/components/pages/Main/Main.tsx
+++ b/client/src/components/pages/Main/Main.tsx
@@ -46,6 +46,7 @@ export interface ScoreInfoType {
   songName: string;
   youtubeURL: string;
   isDeleted: boolean;
+  isOptout: boolean;
 }
 
 function Main() {

--- a/client/src/components/pages/Main/Main.tsx
+++ b/client/src/components/pages/Main/Main.tsx
@@ -118,8 +118,6 @@ function Main() {
     }
   }, [musicArr, key]);
 
-  console.log(musicArr);
-
   // 지정된 요소가 화면에 보일때 실행할 콜백함수
   const onIntersect: IntersectionObserverCallback = useCallback(
     async ([entry], observer) => {

--- a/client/src/components/pages/Main/Main.tsx
+++ b/client/src/components/pages/Main/Main.tsx
@@ -101,13 +101,7 @@ function Main() {
   return (
     <>
       <Carousel />
-      {!loading ? (
-        <>
-          <MainGrid musicData={musicArr} />
-        </>
-      ) : (
-        <Spinner />
-      )}
+      {!loading ? <MainGrid musicData={musicArr} /> : <Spinner />}
       <div className={cx('target')} ref={target}></div>
     </>
   );

--- a/client/src/components/pages/Main/Main.tsx
+++ b/client/src/components/pages/Main/Main.tsx
@@ -17,6 +17,7 @@ import classNames from 'classnames/bind';
 import styles from './main.module.scss';
 import { useDispatch } from 'react-redux';
 import { showFooter } from '../../../redux/FooterSlice';
+import Spinner from '../../../utils/Spinner/Spinner';
 
 export type MusicData = {
   artist: string;
@@ -43,18 +44,18 @@ export interface ScoreInfoType {
   sheetType: string;
   songName: string;
   youtubeURL: string;
+  isDeleted: boolean;
 }
 
 function Main() {
   const cx = classNames.bind(styles);
 
-  const [musicArr, setMusicArr] = useState<MusicData>([
-    { artist: '', scores: [], albumImg: '', songName: '', songId: null },
-  ]);
+  const [musicArr, setMusicArr] = useState<MusicData>([]);
   const [key, setKey] = useState<DocumentData>(); // 마지막으로 불러온 스냅샷 상태
   const [noMore, setNoMore] = useState(false); // 추가로 요청할 데이터 없다는 flag
   const target = useRef() as React.MutableRefObject<HTMLDivElement>;
   const dispatch = useDispatch();
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     dispatch(showFooter(noMore));
@@ -83,6 +84,7 @@ function Main() {
       const docsArray = snap.docs.map((doc: DocumentData) => doc.data());
       // 문서 저장
       setMusicArr(docsArray);
+      setLoading(!loading);
       // 커서로 사용할 마지막 문서 스냅샷 저장
       setKey(snap.docs[snap.docs.length - 1]);
     } catch (err) {
@@ -114,6 +116,8 @@ function Main() {
       console.log(err);
     }
   }, [musicArr, key]);
+
+  console.log(musicArr);
 
   // 지정된 요소가 화면에 보일때 실행할 콜백함수
   const onIntersect: IntersectionObserverCallback = useCallback(
@@ -150,7 +154,13 @@ function Main() {
   return (
     <>
       <Carousel />
-      <MainGrid musicData={musicArr} />
+      {loading ? (
+        <>
+          <MainGrid musicData={musicArr} />
+        </>
+      ) : (
+        <Spinner />
+      )}
       <div className={cx('target')} ref={target}></div>
     </>
   );

--- a/client/src/components/pages/MyPage/MyPage.tsx
+++ b/client/src/components/pages/MyPage/MyPage.tsx
@@ -15,9 +15,62 @@ import classNames from 'classnames/bind';
 import styles from './myPage.module.scss';
 import Spinner from '../../../utils/Spinner/Spinner';
 import { getUserCash } from '../../../firebase/firebase';
+const cx = classNames.bind(styles);
+
+type UploadedDataProps = {
+  clickedTab: '등록한 악보' | '구매한 악보';
+  data: DocumentData[];
+};
+
+const UploadedData = ({ clickedTab, data }: UploadedDataProps) => {
+  const filteredData = data.filter((el: DocumentData) => !el.isDeleted);
+
+  return (
+    <>
+      {clickedTab === '등록한 악보' && (
+        <>
+          {filteredData.map((el: DocumentData, idx: number) => (
+            <div className={cx('wrapper')} key={idx}>
+              <ScoreList score={el} buttonEvent="edit" />
+            </div>
+          ))}
+        </>
+      )}
+      {clickedTab === '구매한 악보' && (
+        <>
+          {data.map((el: DocumentData, idx: number) => (
+            <div className={cx('wrapper')} key={idx}>
+              <ScoreList score={el} buttonEvent="download" />
+            </div>
+          ))}
+        </>
+      )}
+    </>
+  );
+};
+
+const UserData = ({ data, clickedTab, currentPage, setCurrentPage }: any) => {
+  return (
+    <>
+      {data && (
+        <>
+          <div className={cx('container')}>
+            <div className={cx('wrapper')}>
+              <UploadedData clickedTab={clickedTab} data={data} />
+            </div>
+            <Pagination
+              currentPage={currentPage}
+              setCurrentPage={setCurrentPage}
+              totalLists={data.length}
+            />
+          </div>
+        </>
+      )}
+    </>
+  );
+};
 
 const MyPage = () => {
-  const cx = classNames.bind(styles);
   const navigate = useNavigate();
 
   const [loading, setLoading] = useState(true);
@@ -48,62 +101,6 @@ const MyPage = () => {
     }
   }, [user]);
 
-  const UploadedData = ({
-    clickedTab,
-  }: {
-    clickedTab: '등록한 악보' | '구매한 악보';
-  }): ReactElement | null => {
-    if (!data) {
-      return null;
-    }
-
-    const filteredData = data.filter((el: DocumentData) => !el.isDeleted);
-
-    if (clickedTab === '등록한 악보') {
-      return filteredData.map((el: DocumentData, idx: number) => (
-        <div className={cx('wrapper')} key={idx}>
-          <ScoreList score={el} buttonEvent="edit" />
-        </div>
-      ));
-    }
-
-    return data.map((el: DocumentData, idx: number) => (
-      <div className={cx('wrapper')} key={idx}>
-        <ScoreList score={el} buttonEvent="download" />
-      </div>
-    ));
-  };
-
-  const UserData = () => {
-    if (data && clickedTab === '등록한 악보') {
-      return (
-        <div className={cx('container')}>
-          <div className={cx('wrapper')}>
-            <UploadedData clickedTab="등록한 악보" />
-          </div>
-          <Pagination
-            currentPage={currentPage}
-            setCurrentPage={setCurrentPage}
-            totalLists={data.length}
-          />
-        </div>
-      );
-    } else if (data && clickedTab === '구매한 악보') {
-      return (
-        <div className={cx('container')}>
-          <div className={cx('wrapper')}>
-            <UploadedData clickedTab="구매한 악보" />
-          </div>
-          <Pagination
-            currentPage={currentPage}
-            setCurrentPage={setCurrentPage}
-            totalLists={data.length}
-          />
-        </div>
-      );
-    } else return null;
-  };
-
   if (loading) {
     return <Spinner />;
   }
@@ -131,7 +128,12 @@ const MyPage = () => {
                 tabGroupArr={['등록한 악보', '구매한 악보']}
                 setCurrentPage={setCurrentPage}
               />
-              <UserData />
+              <UserData
+                data={data}
+                clickedTab={clickedTab}
+                currentPage={currentPage}
+                setCurrentPage={setCurrentPage}
+              />
             </>
           )}
         </div>

--- a/client/src/components/pages/MyPage/MyPage.tsx
+++ b/client/src/components/pages/MyPage/MyPage.tsx
@@ -1,5 +1,5 @@
 import { MyPageTop } from '../../UI/organisms';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, ReactElement } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { auth } from '../../../firebase/firebase';
 import { User } from 'firebase/auth';
@@ -48,16 +48,38 @@ const MyPage = () => {
     }
   }, [user]);
 
+  const UploadedData = ({
+    clickedTab,
+  }: {
+    clickedTab: '등록한 악보' | '구매한 악보';
+  }): ReactElement | null => {
+    if (!data) {
+      return null;
+    }
+
+    const filteredData = data.filter((el: DocumentData) => !el.isDeleted);
+
+    if (clickedTab === '등록한 악보') {
+      return filteredData.map((el: DocumentData, idx: number) => (
+        <div className={cx('wrapper')} key={idx}>
+          <ScoreList score={el} buttonEvent="edit" />
+        </div>
+      ));
+    }
+
+    return data.map((el: DocumentData, idx: number) => (
+      <div className={cx('wrapper')} key={idx}>
+        <ScoreList score={el} buttonEvent="download" />
+      </div>
+    ));
+  };
+
   const UserData = () => {
     if (data && clickedTab === '등록한 악보') {
       return (
         <div className={cx('container')}>
           <div className={cx('wrapper')}>
-            {data.map((el: DocumentData, idx: number) => (
-              <div className={cx('wrapper')} key={idx}>
-                <ScoreList score={el} buttonEvent="edit" />
-              </div>
-            ))}
+            <UploadedData clickedTab="등록한 악보" />
           </div>
           <Pagination
             currentPage={currentPage}
@@ -70,11 +92,7 @@ const MyPage = () => {
       return (
         <div className={cx('container')}>
           <div className={cx('wrapper')}>
-            {data.map((el: DocumentData, idx: number) => (
-              <div className={cx('wrapper')} key={idx}>
-                <ScoreList score={el} buttonEvent="download" />
-              </div>
-            ))}
+            <UploadedData clickedTab="구매한 악보" />
           </div>
           <Pagination
             currentPage={currentPage}

--- a/client/src/components/pages/MyPage/MyPage.tsx
+++ b/client/src/components/pages/MyPage/MyPage.tsx
@@ -1,7 +1,6 @@
 import { MyPageTop } from '../../UI/organisms';
-import { useState, useEffect, ReactElement } from 'react';
+import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { auth } from '../../../firebase/firebase';
 import { User } from 'firebase/auth';
 import {
   ScoreList,
@@ -9,12 +8,11 @@ import {
   MyPageModal,
   Pagination,
 } from '../../UI/molecules';
-import { getUserArticle } from '../../../firebase/firebase';
+import { getUserArticle, auth, getUserCash } from '../../../firebase/firebase';
 import { DocumentData } from 'firebase/firestore/lite';
 import classNames from 'classnames/bind';
 import styles from './myPage.module.scss';
 import Spinner from '../../../utils/Spinner/Spinner';
-import { getUserCash } from '../../../firebase/firebase';
 const cx = classNames.bind(styles);
 
 type UploadedDataProps = {

--- a/client/src/components/pages/PostMusic/PostMusic.tsx
+++ b/client/src/components/pages/PostMusic/PostMusic.tsx
@@ -1,5 +1,4 @@
 import { useEffect } from 'react';
-
 import classNames from 'classnames/bind';
 import styles from './PostMusic.module.scss';
 import { DropDown, TextEditor, PostSidebar } from '../../UI/molecules';

--- a/client/src/components/pages/PostMusic/PostMusic.tsx
+++ b/client/src/components/pages/PostMusic/PostMusic.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 
 import classNames from 'classnames/bind';
 import styles from './PostMusic.module.scss';

--- a/client/src/components/pages/ScoreInfo/ScoreInfo.tsx
+++ b/client/src/components/pages/ScoreInfo/ScoreInfo.tsx
@@ -7,9 +7,12 @@ import { getScoreByMusic } from '../../../firebase/firebase';
 import { useParams } from 'react-router';
 import { ScoreInfoType } from '../Main/Main';
 import { LoadingSpinner } from '../../UI/atoms';
+import { toast } from 'react-toastify';
+import { useNavigate } from 'react-router';
 
 function ScoreInfo() {
   const cx = classNames.bind(styles);
+  const navigate = useNavigate();
   const [scoreData, setScoreData] = useState<ScoreInfoType>();
   const { scoreName, scoreId } = useParams();
   const dummyData = {
@@ -21,14 +24,30 @@ function ScoreInfo() {
   };
 
   async function fetchScoreData() {
-    if (scoreName && scoreId) {
-      const [data] = await getScoreByMusic(scoreName, scoreId);
-      setScoreData(data);
+    if (!scoreName || !scoreId) {
+      throw new Error('scoreName or scoreId is falsy');
     }
+
+    const [data] = await getScoreByMusic(scoreName, scoreId);
+
+    if (data.isDeleted) {
+      throw new Error('삭제된 게시글이에요');
+    }
+
+    setScoreData(data);
   }
 
   useEffect(() => {
-    fetchScoreData();
+    async function fetchData() {
+      try {
+        await fetchScoreData();
+      } catch (error: any) {
+        toast.error(error.message);
+        navigate('/');
+      }
+    }
+
+    fetchData();
   }, []);
 
   if (scoreData === undefined) {

--- a/client/src/components/pages/ScoreInfo/ScoreInfo.tsx
+++ b/client/src/components/pages/ScoreInfo/ScoreInfo.tsx
@@ -24,30 +24,19 @@ function ScoreInfo() {
   };
 
   async function fetchScoreData() {
-    if (!scoreName || !scoreId) {
-      throw new Error('scoreName or scoreId is falsy');
+    if (scoreName && scoreId) {
+      const [data] = await getScoreByMusic(scoreName, scoreId);
+      if (data.isDeleted) {
+        toast.error('삭제된 게시글이에요');
+        navigate('/');
+      } else {
+        setScoreData(data);
+      }
     }
-
-    const [data] = await getScoreByMusic(scoreName, scoreId);
-
-    if (data.isDeleted) {
-      throw new Error('삭제된 게시글이에요');
-    }
-
-    setScoreData(data);
   }
 
   useEffect(() => {
-    async function fetchData() {
-      try {
-        await fetchScoreData();
-      } catch (error: any) {
-        toast.error(error.message);
-        navigate('/');
-      }
-    }
-
-    fetchData();
+    fetchScoreData();
   }, []);
 
   if (scoreData === undefined) {

--- a/client/src/firebase/firebase.tsx
+++ b/client/src/firebase/firebase.tsx
@@ -601,6 +601,87 @@ export async function userOptout(uid: string) {
   }
 }
 
+// 유저가 게시글을 삭제하면, 해당 게시글의 id를 바탕으로 모든 컬렉션의 scores, posts의 isDeleted 값을 true로 만들어줌
+export async function deleteArticle(uid: string) {
+  /** user 컬렉션 수정 */
+
+  const userRef = doc(db, 'user', uid);
+  const userSnap = await getDoc(userRef);
+  if (userSnap.exists()) {
+    const { posts } = userSnap.data();
+    const scoresWithId = posts.filter((obj: Score) => obj.authorId === uid);
+    scoresWithId.forEach((obj: Score) => (obj.isDeleted = true));
+    await updateDoc(userRef, { posts: posts });
+  }
+  /** music 컬렉션 수정*/
+  const musicRef = collection(db, 'music');
+  const musicSnap = await getDocs(musicRef);
+  const musicList = musicSnap.docs.map((doc: DocumentData) => doc.data());
+  const musicArr = musicList.map((el) => el.scores);
+
+  for (let i = 0; i < musicArr.length; i++) {
+    for (let j = 0; j < musicArr[i].length; j++) {
+      if (musicArr[i][j].authorId === uid) {
+        const songName = `${musicArr[i][j].songName}-${musicArr[i][j].artist}`;
+        const infoRef = doc(db, 'music', songName);
+        const snapshot = await getDoc(infoRef);
+
+        if (snapshot.exists()) {
+          const { scores } = snapshot.data();
+          const scoresWithId = scores.filter(
+            (obj: Score) => obj.authorId === uid
+          );
+          scoresWithId.forEach((obj: Score) => (obj.isDeleted = true));
+
+          await updateDoc(infoRef, { scores: scores });
+        }
+      }
+    }
+  }
+  /** instrument 컬렉션 수정*/
+  const instRef = collection(db, 'instrument');
+  const instSnap = await getDocs(instRef);
+  const instList = instSnap.docs.map((doc: DocumentData) => doc.data());
+
+  const instArr = instList.map((el) => el.scores);
+
+  for (let i = 0; i < instArr.length; i++) {
+    for (let j = 0; j < instArr[i].length; j++) {
+      if (instArr[i][j].authorId === uid) {
+        const data = instArr[i][j];
+        let inst = data.instType;
+        if (inst === '피아노') {
+          inst = 'piano';
+        }
+        if (inst === '어쿠스틱 기타') {
+          inst = 'acoustic';
+        }
+        if (inst === '베이스') {
+          inst = 'bass';
+        }
+        if (inst === '드럼') {
+          inst = 'drum';
+        }
+        if (inst === '일렉 기타') {
+          inst = 'electric';
+        }
+
+        const infoRef = doc(db, 'instrument', inst);
+        const snapshot = await getDoc(infoRef);
+
+        if (snapshot.exists()) {
+          const { scores } = snapshot.data();
+          const scoresWithId = scores.filter(
+            (obj: Score) => obj.authorId === uid
+          );
+          scoresWithId.forEach((obj: Score) => (obj.isDeleted = true));
+
+          await updateDoc(infoRef, { scores: scores });
+        }
+      }
+    }
+  }
+}
 export async function getUserCash(uid: string) {
   const ref = doc(db, 'user', uid);
   const snapshot = await getDoc(ref);

--- a/client/src/redux/PostSlice.tsx
+++ b/client/src/redux/PostSlice.tsx
@@ -140,9 +140,7 @@ export const PostSlice = createSlice({
     setDownloadURL: (state: StateType, action: PayloadAction<string>) => {
       state.scores[0].downloadURL = action.payload;
     },
-    initializeState: (state: StateType) => {
-      return (state = initialState);
-    },
+    initializeState: () => initialState,
   },
 });
 

--- a/client/src/redux/PostSlice.tsx
+++ b/client/src/redux/PostSlice.tsx
@@ -37,6 +37,7 @@ export interface Score {
   albumImg: string;
   downloadURL: string;
   isOptout: boolean;
+  isDeleted: boolean;
 }
 
 export interface StateType {
@@ -74,6 +75,7 @@ const initialState: StateType = {
       albumImg: '',
       downloadURL: '',
       isOptout: false,
+      isDeleted: false,
     },
   ],
 };

--- a/client/src/utils/ApiCollection/User.tsx
+++ b/client/src/utils/ApiCollection/User.tsx
@@ -50,27 +50,31 @@ export const handleRegisterUser = async (
   password: any,
   nickname: any
 ) => {
+  let response;
   await createUserWithEmailAndPassword(auth, email, password)
     .then(async (userCredential) => {
       const user = userCredential.user;
       const ref = doc(db, 'user', user.uid);
       const snapshot = await getDoc(ref);
+      response = user;
       if (snapshot.exists()) {
         toast.error('이미 가입한 회원이세요!');
       } else {
-        userInitData(user.uid);
-        updateProfile(user, {
+        await userInitData(user.uid);
+        await updateProfile(user, {
           displayName: nickname,
           photoURL: Avatar(),
         });
-        handleUserLogin(email, password);
+        localStorage.setItem('authorization', user.uid);
+        localStorage.setItem('refresh', user.refreshToken);
+        await handleUserLogin(email, password);
       }
     })
     .catch((error) => {
       console.log(error.code);
     });
 
-  return;
+  return response;
 };
 
 export const handleGoogleLogin = async () => {

--- a/client/src/utils/ApiCollection/User.tsx
+++ b/client/src/utils/ApiCollection/User.tsx
@@ -24,6 +24,11 @@ export const handleUserLogin = async (email: string, password: string) => {
           : localStorage.setItem('authorization', user.uid);
         localStorage.setItem('refresh', user.refreshToken);
         response = user;
+      } else {
+        userInitData(user.uid);
+        localStorage.setItem('authorization', user.uid);
+        localStorage.setItem('refresh', user.refreshToken);
+        response = user;
       }
     })
     .catch((error) => {


### PR DESCRIPTION
📌 유저가 게시글을 삭제하면 music, inst , user 컬렉션에서 해당 데이터의 isDeleted 값이 true가 됩니다.
- 이를 활용하여 메인페이지, 악보페이지, 마이페이지 등에서 isDeleted가 true인 경우 해당 데이터를 필터링하는 로직을 추가했습니다.
- 만약 제가 빼먹은 곳이 있다면 참고하여 반영 부탁드립니다ㅎㅎ!!

📌 회원탈퇴시 해당 유저가 작성한 모든 데이터의 isOptout 값이 true가 됩니다. isDeleted와 isOptout 값 모두 true일 경우 music 컬렉션에서 부모의 isDeleted값이 true가 됩니다.

📌 삭제된 게시글에 접근하면 메인화면으로 navigate 합니다. 게시글이 삭제가 되어도 구매한 내역에서는 남아있어 악보를 받을 수 있게 했습니다.

📌 메인페이지의 MainSongSection의 idx 값의 기준을 바꾸는 slice 를 추가했습니다. 삭제를해도 데이터가 남아 해당 idx를 차지하는 이슈가 있었습니다!


리펙토링이 필요한 부분이 보여서 해당 작업이 끝나면 머지하겠습니다!
