### PR TITLE
Feat: 탭 메뉴 로직 변경 및 악기 상세, 곡 상세페이지 모바일 반응형 구현

### DIFF
--- a/client/src/components/UI/molecules/ScoreList/scoreList.module.scss
+++ b/client/src/components/UI/molecules/ScoreList/scoreList.module.scss
@@ -1,63 +1,143 @@
 @import '/src/utils/utils';
 
 .wrapper {
+  width: 100%;
+  max-width: #{1220/$font-size}rem;
+  margin-bottom: 10px;
+  padding: 10px;
+  border-radius: 10px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  a {
     width: 100%;
-    max-width: #{1220/$font-size}rem;
-    margin-bottom: 10px;
-    padding: 10px;
-    border-radius: 10px;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
 
-    a {
-        width: 100%;
+    .detail {
+      flex: 1;
+      display: flex;
+      align-items: center;
 
-        .detail {
-            flex: 1;
-            display: flex;
-            align-items: center;
+      .score-song {
+        flex-basis: 40%;
+        padding-left: 8px;
+      }
 
-            .score-song {
-                flex-basis: 40%;
-                padding-left: 8px;
-            }
+      .score-info {
+        flex-basis: 60%;
+        display: flex;
+        justify-content: space-between;
 
-            .score-info {
-                flex-basis: 60%;
-                display: flex;
-                justify-content: space-between;
+        li {
+          flex-basis: 30%;
 
-                li {
-                    flex-basis: 30%;
+          &:first-child {
+            flex-basis: 40%;
+          }
+        }
+      }
 
-                    &:first-child {
-                        flex-basis: 40%;
-                    }
-                }
-            }
+      li {
+        line-height: 1.5;
+        padding-right: 1rem;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        display: -webkit-box;
+        -webkit-line-clamp: 1;
+        -webkit-box-orient: vertical;
+        word-break: break-all;
+      }
+    }
 
-            li {
-                line-height: 1.5;
-                padding-right: 1rem;
-                overflow: hidden;
-                text-overflow: ellipsis;
-                display: -webkit-box;
-                -webkit-line-clamp: 1;
-                -webkit-box-orient: vertical;
-                word-break: break-all;
-            }
+  }
+
+  .price {
+    min-width: #{85/$font-size}rem;
+    text-align: center;
+  }
+
+  &:hover {
+    background-color: $gray-white;
+    transition: all .1s ease-in;
+  }
+}
+
+@include mobile {
+  .wrapper {
+    margin-bottom: 0;
+    
+    >a {
+      .detail {
+        display: block;
+
+        span {
+          font-size: 1.2rem;
         }
 
+        .score-song {
+          padding: 0;
+          display: flex;
+
+          li {
+            &:first-child {
+              padding: 0;
+            }
+
+            &:last-child {
+              position: relative;
+              padding-left: 1.5rem;
+
+              span {
+                color: $black;
+              }
+
+              &::after {
+                content: '';
+                width: 8px;
+                height: 1px;
+                background-color: $black;
+                position: absolute;
+                top: 10px;
+                left: 5px;
+              }
+            }
+          }
+        }
+
+        .score-info {
+          justify-content: flex-start;
+
+          >li {
+            position: relative;
+            flex: none;
+            padding-right: 1rem;
+            &::after {
+              content: '';
+              width: 3px;
+              height: 3px;
+              border-radius: 50%;
+              background-color: $gray;
+              position: absolute;
+              top: 9px;
+              right: 5px;
+            }
+
+            &:last-child::after {
+              display: none;
+            }
+
+            &:first-child {
+              flex: 0 1 auto;
+            }
+          }
+        }
+      }
     }
 
     .price {
-        min-width: #{85/$font-size}rem;
-        text-align: center;
+      span {
+        font-size: 1.2rem;
+      }
     }
-
-    &:hover {
-        background-color: $gray-white;
-        transition: all .1s ease-in;
-    }
+  }
 }

--- a/client/src/components/UI/molecules/TabMenu/TabMenu.stories.tsx
+++ b/client/src/components/UI/molecules/TabMenu/TabMenu.stories.tsx
@@ -14,10 +14,10 @@ export const Default = Template.bind({});
 Default.args = {
   tabGroupArr: [
     '전체',
-    '피아노',
     '일렉 기타',
     '어쿠스틱 기타',
     '베이스',
     '드럼',
+    '피아노',
   ],
 };

--- a/client/src/components/UI/molecules/TabMenu/TabMenu.tsx
+++ b/client/src/components/UI/molecules/TabMenu/TabMenu.tsx
@@ -1,4 +1,4 @@
-import { Button, Text } from '../../atoms';
+import { Button, Icon, Text } from '../../atoms';
 import styles from './tabMenu.module.scss';
 import classNames from 'classnames/bind';
 import { Dispatch, SetStateAction, useState } from 'react';
@@ -16,29 +16,87 @@ const TabMenu = ({
 }: TabMenuProps) => {
   const cx = classNames.bind(styles);
   const [currentTab, setCurrentTab] = useState(0);
+  const [moreTab, setMoreTab] = useState('더보기');
+  const [dropdown, setDropdown] = useState(false);
 
   const handleClick = (tab: string, idx: number) => {
     setCurrentTab(idx);
     setClickedTab(tab);
     setCurrentPage(1);
+    setMoreTab('더보기');
+    setDropdown(false);
+  };
+
+  const handleMoreClick = (tab: string, idx: number) => {
+    setMoreTab(tab);
+    setCurrentTab(idx);
+    setClickedTab(tab);
+    setCurrentPage(1);
+    setDropdown(false);
   };
 
   return (
     <div className={cx('wrapper')}>
       <ul className={cx('tabs')}>
-        {tabGroupArr.map((tab, idx) => (
-          <li key={idx} className={cx('tab', currentTab === idx && 'active')}>
+        {tabGroupArr.map(
+          (tab, idx) =>
+            idx < 3 && (
+              <li
+                key={idx}
+                className={cx('tab', currentTab === idx && 'active')}
+              >
+                <Button
+                  theme="transparent"
+                  size="auto"
+                  onClick={() => handleClick(tab, idx)}
+                >
+                  <Text size="lg" color="gray">
+                    {tab}
+                  </Text>
+                </Button>
+              </li>
+            )
+        )}
+        {tabGroupArr.length > 3 && (
+          <li className={cx('tab', currentTab > 2 && 'active')}>
             <Button
               theme="transparent"
               size="auto"
-              onClick={() => handleClick(tab, idx)}
+              onClick={() => setDropdown(!dropdown)}
             >
-              <Text size="lg" color="gray">
-                {tab}
-              </Text>
+              <>
+                <Text size="lg" color="gray">
+                  {moreTab}
+                </Text>
+                <Icon
+                  icon={
+                    dropdown ? 'MdOutlineArrowDropUp' : 'MdOutlineArrowDropDown'
+                  }
+                  size="xs"
+                  color={currentTab > 2 ? 'black' : 'gray'}
+                />
+              </>
             </Button>
+            <ul className={cx('more-tab', dropdown && 'show')}>
+              {tabGroupArr.map(
+                (tab, idx) =>
+                  idx > 2 && (
+                    <li key={idx}>
+                      <Button
+                        theme="transparent"
+                        size="auto"
+                        onClick={() => handleMoreClick(tab, idx)}
+                      >
+                        <Text size="lg" color="gray">
+                          {tab}
+                        </Text>
+                      </Button>
+                    </li>
+                  )
+              )}
+            </ul>
           </li>
-        ))}
+        )}
       </ul>
     </div>
   );

--- a/client/src/components/UI/molecules/TabMenu/tabMenu.module.scss
+++ b/client/src/components/UI/molecules/TabMenu/tabMenu.module.scss
@@ -5,6 +5,7 @@
   display: flex;
   justify-content: center;
   background-color: #d9eddf;
+  padding: 0 2.4rem;
 
   .tabs {
     width: 100%;
@@ -15,9 +16,18 @@
     position: relative;
 
     .tab {
+      flex: none;
       position: relative;
-      margin: 0 1rem;
+      margin: 0 5px;
       padding: 0 1rem;
+
+      &:first-child {
+        margin-left: 0;
+      }
+      &:nth-child(4) {
+        margin-right: 0;
+        padding-right: 5px;
+      }
 
       span:last-child {
         &:hover {
@@ -48,7 +58,7 @@
           }
         }
 
-        span:last-child {
+        span:first-child {
           color: $black;
         }
       }

--- a/client/src/components/UI/molecules/TabMenu/tabMenu.module.scss
+++ b/client/src/components/UI/molecules/TabMenu/tabMenu.module.scss
@@ -62,6 +62,27 @@
           color: $black;
         }
       }
+
+      .more-tab {
+        display: none;
+        position: absolute;
+        top: 2.5rem;
+        left: 0;
+        width: 6rem;
+        padding: 5px 10px 5px 1.2rem;
+        background-color: $white;
+        box-shadow: 0 0 10px rgba($black, .15);
+        border-radius: 10px;
+        border: 1px solid $gray-white;
+
+        >li {
+          padding: 10px 0;
+        }
+
+        &.show {
+          display: block;
+        }
+      }
     }
   }
 }

--- a/client/src/components/UI/molecules/TabMenu/tabMenu.module.scss
+++ b/client/src/components/UI/molecules/TabMenu/tabMenu.module.scss
@@ -86,3 +86,17 @@
     }
   }
 }
+
+@include mobile {
+  .wrapper {
+    padding: 0 2rem 0 1.5rem;
+
+    .tabs {
+      padding-top: 0;
+
+      .tab {
+        margin-left: 0;
+      }
+    }
+  }
+}

--- a/client/src/components/UI/organisms/CartModal/CartModal.tsx
+++ b/client/src/components/UI/organisms/CartModal/CartModal.tsx
@@ -36,6 +36,8 @@ function CartModal() {
 
   useEffect(() => {
     setShow('show');
+    document.body.setAttribute('style', 'overflow: hidden;');
+    return () => document.body.setAttribute('style', 'overflow: auto;');
   }, []);
 
   return (

--- a/client/src/components/UI/organisms/CategoryDetail/CategoryDetail.module.scss
+++ b/client/src/components/UI/organisms/CategoryDetail/CategoryDetail.module.scss
@@ -1,33 +1,46 @@
 @import '/src/utils/utils';
 
 .cover-wrapper {
-    width: 100%;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    padding: 1.5rem 2.4rem;
-    background-color: #d9eddf;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 1.5rem 2.4rem;
+  background-color: #d9eddf;
 }
+
 .container {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0 #{28.4/$font-size}rem;
+  margin-top: 3rem;
+
+  h2 {
     width: 100%;
+    max-width: 1220px;
+    padding-left: 1rem;
+  }
+
+  .score-lists {
+    width: 100%;
+    max-width: 1220px;
     display: flex;
     flex-direction: column;
     align-items: center;
-    padding: 0 #{28.4/$font-size}rem;
-    margin-top: 3rem;
+    margin-top: 1rem;
+  }
+}
+
+
+@include mobile {
+  .container {
+    padding: 0 10px;
+    margin-top: 2rem;
 
     h2 {
-        width: 100%;
-        max-width: 1220px;
-        padding-left: 1rem;
+      padding-left: 10px;
     }
-
-    .score-lists {
-        width: 100%;
-        max-width: 1220px;
-        display: flex;
-        flex-direction: column;
-        align-items: center;   
-        margin-top: 1rem; 
-    }
+  }
 }

--- a/client/src/components/UI/organisms/CategoryDetail/CategoryDetail.module.scss
+++ b/client/src/components/UI/organisms/CategoryDetail/CategoryDetail.module.scss
@@ -35,6 +35,24 @@
 
 
 @include mobile {
+  .cover-wrapper {
+    padding: 1.5rem;
+
+    >div>div {
+      &:first-child>div {
+        width: 10rem;
+        height: 10rem;
+      }
+      &:last-child {
+        padding: 10px 0 1rem 1.5rem;
+        >ul>li:nth-child(2) {
+          padding-top: 1.5rem;
+        }
+      }
+    }
+
+  }
+
   .container {
     padding: 0 10px;
     margin-top: 2rem;

--- a/client/src/components/UI/organisms/PostHeader/PostHeader.tsx
+++ b/client/src/components/UI/organisms/PostHeader/PostHeader.tsx
@@ -45,7 +45,8 @@ const PostHeader = () => {
       !scores[0].sheetType ||
       !scores[0].detail ||
       !scores[0].price ||
-      !scores[0].downloadURL
+      !scores[0].downloadURL ||
+      !scores[0].scoreName
     ) {
       return false;
     }


### PR DESCRIPTION
탭 메뉴 로직 변경
--
기존의 모두 나열하는 방식은 pc~tablet 사이즈에서는 문제가 없지만, 악기 종류가 많은 경우 탭메뉴의 길이 길어져 모바일에서는 짤리는 이슈가 있어서 로직을 변경했습니다.
- 악기 종류가 2개 이하인 경우 : `전체, 악기1, 악기2`와 같이 단순 나열합니다.
- 악기 종류가 3개 이상인 경우: `전체, 악기1, 악기2, 더보기`와 같이 3번째 악기부터는 더보기 그룹에 포함되며, 더보기 클릭시 드롭다운 형식으로 표시합니다.
- 로직의 변화가 있지만 탭 메뉴와 관련이 있는 다른 컴포넌트에는 영향을 미치지 않으며 active 애니메이션도 변경된 로직에 적합하도록 수정했습니다.
- 변경된 로직은 모든 뷰포트에서 적용됩니다. (모바일 한정X)

곡 상세페이지, 악기 상세페이지 모바일 반응형
--
- 악보 리스트가 모바일 환경에 적합하도록 피그마 디자인처럼 배치를 변경했습니다.
- 그 외 커버 부분의 이미지나 곡 제목 등등 사이즈를 줄였습니다.

⭐️ etc
--
- 게시글 작성페이지의 유효성 검사에 악보 제목이 누락된거 같아서 추가해뒀습니다. 혹시 의도하신거면 지우셔도 됩니당!
- 장바구니 스크롤 숨기는 로직은 함께 올릴까 말까 고민하다 일단 추가해뒀습니다. 규식님께서 원하시는대로 수정하시거나 지우셔도 됩니당!


