### PR TITLE
Design: ScoreInfo 페이지 반응형 구현

### DIFF
--- a/client/src/components/UI/molecules/ScoreInfoCard/scoreinfocard.module.scss
+++ b/client/src/components/UI/molecules/ScoreInfoCard/scoreinfocard.module.scss
@@ -11,7 +11,7 @@
   .scoreinfo-item {
     display: flex;
     margin: 1rem 0;
-    @media screen and (max-width: 399px) {
+    @media screen and (max-width: 415px) {
       width: 50%;
       justify-content: center;
     }

--- a/client/src/components/UI/molecules/ScoreInfoCard/scoreinfocard.module.scss
+++ b/client/src/components/UI/molecules/ScoreInfoCard/scoreinfocard.module.scss
@@ -11,6 +11,10 @@
   .scoreinfo-item {
     display: flex;
     margin: 1rem 0;
+    @media screen and (max-width: 399px) {
+      width: 50%;
+      justify-content: center;
+    }
     span {
       display: flex;
       align-items: center;

--- a/client/src/components/UI/molecules/ScoreInfoHeader/scoreinfoheader.module.scss
+++ b/client/src/components/UI/molecules/ScoreInfoHeader/scoreinfoheader.module.scss
@@ -11,6 +11,13 @@
 
     span {
       margin: 0.25rem 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      display: -webkit-box;
+      -webkit-line-clamp: 1;
+      -webkit-box-orient: vertical;
+      word-break: break-all;
+      margin: 0.25rem 0.5rem;
     }
   }
 

--- a/client/src/components/UI/molecules/ScorePriceCard/scorepricecard.module.scss
+++ b/client/src/components/UI/molecules/ScorePriceCard/scorepricecard.module.scss
@@ -12,6 +12,10 @@
   justify-content: space-between;
   background: $white;
 
+  // @include mobile {
+  //   width: 80%;
+  // }
+
   > span {
     padding-left: 0.5rem;
   }

--- a/client/src/components/UI/molecules/ScorePriceCard/scorepricecard.module.scss
+++ b/client/src/components/UI/molecules/ScorePriceCard/scorepricecard.module.scss
@@ -12,10 +12,6 @@
   justify-content: space-between;
   background: $white;
 
-  // @include mobile {
-  //   width: 80%;
-  // }
-
   > span {
     padding-left: 0.5rem;
   }
@@ -23,5 +19,9 @@
   button {
     width: 17.5rem;
     height: 3rem;
+    @include mobile {
+      width: 100%;
+      // width: 25rem;
+    }
   }
 }

--- a/client/src/components/UI/organisms/ScoreInfoAside/scoreInfoAside.module.scss
+++ b/client/src/components/UI/organisms/ScoreInfoAside/scoreInfoAside.module.scss
@@ -1,7 +1,14 @@
 @import '/src/utils/utils';
 
 .scoreinfo-aside {
+  @include mobile {
+    width: 100%;
+    max-width: 426px;
+  }
   > div {
     margin-top: 1rem;
+    @include mobile {
+      width: 100%;
+    }
   }
 }

--- a/client/src/components/UI/organisms/ScoreInfoAside/scoreInfoAside.module.scss
+++ b/client/src/components/UI/organisms/ScoreInfoAside/scoreInfoAside.module.scss
@@ -2,8 +2,10 @@
 
 .scoreinfo-aside {
   @include mobile {
+    display: flex;
+    flex-wrap: wrap-reverse;
     width: 100%;
-    max-width: 426px;
+    max-width: 375px;
   }
   > div {
     margin-top: 1rem;

--- a/client/src/components/UI/organisms/ScoreInfoMain/ScoreInfoMain.tsx
+++ b/client/src/components/UI/organisms/ScoreInfoMain/ScoreInfoMain.tsx
@@ -47,7 +47,7 @@ function ScoreInfoMain({
   };
 
   const opts: YouTubeProps['opts'] = {
-    width: '700',
+    width: '100%',
     height: '400',
     playerVars: {
       autoplay: 1,

--- a/client/src/components/UI/organisms/ScoreInfoMain/scoreInfoMain.module.scss
+++ b/client/src/components/UI/organisms/ScoreInfoMain/scoreInfoMain.module.scss
@@ -1,5 +1,26 @@
 @import '/src/utils/utils';
 
-.scoreinfo-main > div {
-  margin-top: 2.5rem;
+.scoreinfo-main {
+  > div {
+    margin-top: 2.5rem;
+
+    @include mobile {
+      > iframe {
+        height: auto;
+        min-height: 250px;
+      }
+    }
+
+    > img:nth-child(2) {
+      @include mobile {
+        display: none;
+      }
+    }
+  }
+
+  > div:nth-child(1) {
+    @include mobile {
+      justify-content: center;
+    }
+  }
 }

--- a/client/src/components/pages/ScoreInfo/scoreInfo.module.scss
+++ b/client/src/components/pages/ScoreInfo/scoreInfo.module.scss
@@ -6,6 +6,10 @@
   grid-template-rows: auto;
   position: relative;
 
+  @include mobile {
+    grid-template-columns: auto;
+  }
+
   > div:first-child {
     grid-column: 2 / 3;
     grid-row: 1 / 2;
@@ -14,6 +18,8 @@
 
     @include mobile {
       grid-column: 1 / 2;
+      margin-left: 1rem;
+      margin-right: 1rem;
     }
   }
 
@@ -30,16 +36,17 @@
       grid-column: 1 / 2;
       position: static;
       grid-row: 2 / 3;
+      justify-self: center;
+      margin: 0 1rem;
     }
   }
   > aside:nth-child(3) {
     grid-column: 1 / 2;
     grid-row: 1 / 2;
     margin: 0 0.5rem;
-  }
-
-  @include mobile {
-    grid-template-columns: 1fr;
-    grid-row: 3 / 4;
+    @include mobile {
+      grid-template-columns: 1fr;
+      grid-row: 3 / 4;
+    }
   }
 }

--- a/client/src/components/pages/ScoreInfo/scoreInfo.module.scss
+++ b/client/src/components/pages/ScoreInfo/scoreInfo.module.scss
@@ -11,6 +11,10 @@
     grid-row: 1 / 2;
     justify-self: center;
     margin-top: 2rem;
+
+    @include mobile {
+      grid-column: 1 / 2;
+    }
   }
 
   > aside:nth-child(2) {
@@ -21,10 +25,21 @@
     height: #{330 / $font-size}rem;
     margin-left: 2.5rem;
     margin-right: 1rem;
+
+    @include mobile {
+      grid-column: 1 / 2;
+      position: static;
+      grid-row: 2 / 3;
+    }
   }
   > aside:nth-child(3) {
     grid-column: 1 / 2;
     grid-row: 1 / 2;
     margin: 0 0.5rem;
+  }
+
+  @include mobile {
+    grid-template-columns: 1fr;
+    grid-row: 3 / 4;
   }
 }

--- a/client/src/components/pages/ScoreInfo/scoreInfo.module.scss
+++ b/client/src/components/pages/ScoreInfo/scoreInfo.module.scss
@@ -37,7 +37,7 @@
       position: static;
       grid-row: 2 / 3;
       justify-self: center;
-      margin: 0 1rem;
+      margin: 0;
     }
   }
   > aside:nth-child(3) {


### PR DESCRIPTION
ScoreInfo 페이지 반응형 구현

- mobile px

aside가 밑으로 빠지면서 유저 카드가 위로,  장바구니 카드가 아래로 순서가 바뀝니다.

미리보기 악보 이미지가 한장만 나타납니다.

- 415px

 가운데 악보 정보 박스가 2단으로 변경되도록 했습니다.