### PR TITLE
Design: 메인페이지 반응형 구현

### DIFF
--- a/client/src/components/UI/organisms/Carousel/carousel.scss
+++ b/client/src/components/UI/organisms/Carousel/carousel.scss
@@ -15,6 +15,10 @@
   &.third {
     background-image: url('../../../../assets/carousel_bg3.png');
   }
+
+  @include mobile {
+    height: 20rem;
+  }
   .carousel-detail-wrapper {
     display: flex;
     flex-direction: column;
@@ -24,12 +28,15 @@
     > span:nth-child(2) {
       margin: 0 0 4rem 0;
       font-size: 3rem;
+      @include mobile {
+        font-size: 2rem;
+      }
     }
     button {
       width: 7rem;
       height: 2rem;
 
-      span{
+      span {
         &:first-child {
           padding: 0 3px;
         }
@@ -44,17 +51,26 @@
   img {
     height: 15rem;
     object-fit: cover;
+    @include mobile {
+      height: 10rem;
+    }
   }
 }
 
 .swiper-button-prev {
   color: $white;
   margin-left: 1rem;
+  @include mobile {
+    display: none;
+  }
 }
 
 .swiper-button-next {
   color: $white;
   margin-right: 1rem;
+  @include mobile {
+    display: none;
+  }
 }
 
 .swiper-pagination-bullet {

--- a/client/src/components/UI/organisms/MainGrid/maingrid.module.scss
+++ b/client/src/components/UI/organisms/MainGrid/maingrid.module.scss
@@ -2,20 +2,27 @@
 
 .main-content-grid {
   padding: 0 2.4rem;
-
-  .main-content-header {
-    margin-top: 3.5rem;
-    grid-column: 1 / -1;
-  }
   display: grid;
   column-gap: 8rem;
   row-gap: 4rem;
   width: 100%;
   justify-content: center;
-  grid-template-columns: repeat(2, minmax(400px, 500px));
+  grid-template-columns: repeat(2, minmax(auto, 500px));
   grid-template-rows: 100px;
   grid-auto-rows: auto;
-  @media screen and (max-width: 880px) {
-    grid-template-columns: repeat(1, minmax(400px, 500px));
+  @media screen and (max-width: 970px) {
+    grid-template-columns: repeat(1, minmax(auto, 500px));
+  }
+  @include mobile {
+    grid-template-rows: 50px;
+  }
+
+  .main-content-header {
+    margin-top: 3.5rem;
+    grid-column: 1 / -1;
+    max-width: 36rem;
+    @include mobile {
+      margin-top: 3rem;
+    }
   }
 }

--- a/client/src/components/UI/organisms/MainSongSection/mainsongsection.module.scss
+++ b/client/src/components/UI/organisms/MainSongSection/mainsongsection.module.scss
@@ -5,6 +5,7 @@
   flex-direction: column;
   width: 100%;
   max-width: 36rem;
+  justify-self: center;
 
   .scorelist-wrapper {
     margin-top: 0.5rem;


### PR DESCRIPTION
메인페이지 반응형 구현

기존에는 MainSongSection 그리드 열이 2열이였다가 1열로 주는 정도의 반응형만 있었으나,

이번에 1열로 줄어든 뒤에 400px 이하로 더 줄였을때 MainSongSection의 비율이 망가지는 문제를 수정했습니다.

Carousel도 반응형에 맞춰서 바뀌도록 수정했습니다.