### PR TITLE
Feat: ScoreInfo 페이지에서 uid와 authorId가 일치할 때만 수정, 삭제 버튼이 노출되도록 로직추가

### DIFF
--- a/client/src/components/UI/molecules/ScoreInfoHeader/ScoreInfoHeader.tsx
+++ b/client/src/components/UI/molecules/ScoreInfoHeader/ScoreInfoHeader.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { Text, Button } from '../../atoms';
 import styles from './scoreinfoheader.module.scss';
 import classNames from 'classnames/bind';
@@ -9,9 +10,17 @@ interface ScoreInfoHeaderProps {
   scoreName: string;
   singer: string;
   date: string | number;
+  authorId: string;
+  uid: string | undefined;
 }
 
-function ScoreInfoHeader({ scoreName, singer, date }: ScoreInfoHeaderProps) {
+function ScoreInfoHeader({
+  scoreName,
+  singer,
+  date,
+  authorId,
+  uid,
+}: ScoreInfoHeaderProps) {
   const cx = classNames.bind(styles);
   const navigate = useNavigate();
   const params = useParams();
@@ -37,24 +46,26 @@ function ScoreInfoHeader({ scoreName, singer, date }: ScoreInfoHeaderProps) {
         <Text size="m">{singer}</Text>
         <Text size="m">{formattedDate}</Text>
       </div>
-      <div className={cx('button-wrapper')}>
-        <Button
-          theme="transparent"
-          size="auto"
-          onClick={() => {
-            navigate(`/scores/edit${pathname}`);
-          }}
-        >
-          <Text color="gray">수정</Text>
-        </Button>
-        <Button
-          theme="transparent"
-          size="auto"
-          onClick={() => handleDeleteArticle()}
-        >
-          <Text color="gray">삭제</Text>
-        </Button>
-      </div>
+      {uid === authorId && (
+        <div className={cx('button-wrapper')}>
+          <Button
+            theme="transparent"
+            size="auto"
+            onClick={() => {
+              navigate(`/scores/edit${pathname}`);
+            }}
+          >
+            <Text color="gray">수정</Text>
+          </Button>
+          <Button
+            theme="transparent"
+            size="auto"
+            onClick={() => handleDeleteArticle()}
+          >
+            <Text color="gray">삭제</Text>
+          </Button>
+        </div>
+      )}
     </div>
   );
 }

--- a/client/src/components/pages/ScoreInfo/ScoreInfo.tsx
+++ b/client/src/components/pages/ScoreInfo/ScoreInfo.tsx
@@ -13,11 +13,13 @@ import { useDispatch } from 'react-redux';
 import { countCartItem } from '../../../redux/ModalSlice';
 import { auth } from '../../../firebase/firebase';
 import { useNavigate } from 'react-router';
+import { User } from 'firebase/auth';
 
 function ScoreInfo() {
   const cx = classNames.bind(styles);
   const navigate = useNavigate();
   const [scoreData, setScoreData] = useState<ScoreInfoType>();
+  const [user, setUser] = useState<User | null>(null);
   const { scoreName, scoreId } = useParams();
   const dispatch = useDispatch();
   const dummyData = {
@@ -75,6 +77,10 @@ function ScoreInfo() {
 
   useEffect(() => {
     fetchScoreData();
+    const unsubscribe = auth.onAuthStateChanged((user) => {
+      setUser(user as User);
+    });
+    return unsubscribe;
   }, []);
 
   if (scoreData === undefined) {
@@ -90,6 +96,8 @@ function ScoreInfo() {
               scoreName={scoreData.scoreName}
               singer={scoreData.artist}
               date={scoreData.createdAt}
+              authorId={scoreData.authorId}
+              uid={user?.uid}
             />
             <ScoreInfoMain
               scoreImg1={dummyData.scoreImg1}


### PR DESCRIPTION
ScoreInfo 페이지에서

firebase를 통해 받아온 uid와 authorId가 일치할 때에만

수정, 삭제 버튼이 노출되도록 했습니다.